### PR TITLE
libapp: refactor to a better architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ initrd/files
 *.pcap
 *.lock
 
+# Javascript
+**/node_modules/**
+
 # GDB
 .gdbinit
 

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -29,6 +29,19 @@ function(add_os_static_library target_name short_name has_headers)
     set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${short_name})
 endfunction()
 
+function(generate_interface target id input output)
+    add_custom_command(
+        OUTPUT ${output}
+        COMMAND node ${ROOT}/gen/reflect/index.js -i ${input} -o ${output}
+        DEPENDS ${ROOT}/gen/reflect/index.js
+        MAIN_DEPENDENCY ${input}
+        VERBATIM
+    )
+    add_custom_target(generate_interface_${id} DEPENDS ${output})
+    add_dependencies(${target} generate_interface_${id})
+    target_include_directories(${target} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
+endfunction()
+
 function(add_os_tests name)
     set(test_name "test_${name}")
     set(test_executable "${CMAKE_CURRENT_BINARY_DIR}/${test_name}")

--- a/gen/CMakeLists.txt
+++ b/gen/CMakeLists.txt
@@ -4,3 +4,5 @@ set(TARGETS
 )
 
 add_all_targets()
+
+add_subdirectory(reflect)

--- a/gen/reflect/CMakeLists.txt
+++ b/gen/reflect/CMakeLists.txt
@@ -1,0 +1,1 @@
+execute_process(COMMAND npm install)

--- a/gen/reflect/index.js
+++ b/gen/reflect/index.js
@@ -1,0 +1,131 @@
+const yargs = require("yargs");
+const fs = require("fs");
+
+const result = yargs
+    .option("output", {
+        alias: "o",
+        description: "Output file path",
+        type: "string",
+    })
+    .option("input", {
+        alias: "i",
+        description: "Input file path",
+        type: "string",
+    })
+    .option("namespace", {
+        alias: "n",
+        description: "Target namespace",
+        type: "string",
+    })
+    .help().argv;
+
+const contents = fs.readFileSync(result["input"], "utf8");
+const relevant = contents.replace(/[\s\S]*\/\/ os_2 reflect begin([\s\S]*)\/\/ os_2 reflect end[\s\S]*/gm, "$1");
+
+const removeMultilineImplementation = (s) => {
+    let fixed = "";
+    let buffer = "";
+    let count = 0;
+    for (const c of s) {
+        if (c == "{") {
+            buffer = "";
+            count++;
+        }
+        if (c == "}") {
+            if (--count === 0) {
+                fixed += buffer;
+            }
+        }
+        if (count > 0) {
+            if (c !== "\n") {
+                buffer += c;
+            }
+        } else {
+            fixed += c;
+        }
+    }
+    return fixed;
+};
+
+const fixTemplates = (s) => {
+    return s.replaceAll(/template(.*)\n(.*)/gm, "template$1$2");
+};
+
+const lines = fixTemplates(removeMultilineImplementation(relevant))
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+const processParams = (p) => {
+    const items = p
+        .substring(1, p.length - 1)
+        .split(",")
+        .filter((x) => x.length !== 0);
+    return items.map((s) => {
+        const names = s.split(" ").filter((x) => x.length !== 0);
+        const type = names.slice(0, names.length - 1).join(" ");
+        const name = names[names.length - 1];
+        return { type, name };
+    });
+};
+
+const methods = lines
+    .map((line) => {
+        return line.replaceAll("virtual", "").replaceAll(" = 0;", "").replaceAll(/{.*}/g, "").replaceAll(";", "").trim();
+    })
+    .map((line) => {
+        return line.split(" ");
+    })
+    .map((line) => {
+        const index = line.findIndex((s) => s.includes("("));
+        return [line.slice(0, index).join(" "), line[index], ...line.slice(index + 1)];
+    })
+    .map((line) => {
+        if (line[line.length - 1] === "const") {
+            return [line[0], line.slice(1, line.length - 1).join(" "), line[line.length - 1]];
+        }
+        return [line[0], line.slice(1).join(" "), ""];
+    })
+    .map((line) => {
+        return [line[0], line[1].split("(")[0], "(" + line[1].split("(")[1], line[2]];
+    })
+    .map((line) => {
+        return { returnType: line[0], name: line[1], params: processParams(line[2]), modifiers: line[3] };
+    });
+
+const forwardMethod = (method) => {
+    const processArg = ({ type, name }) => {
+        if (type.includes("...")) {
+            return `forward<${type.replaceAll("&&", "").replaceAll("...", "")}>(${name})...`;
+        }
+        return `forward<${type}>(${name})`;
+    };
+
+    const processTemplate = (s) => {
+        if (!s.includes("template")) {
+            return "";
+        }
+        const args = processParams(s.replaceAll(/.*template(<.*>  ).*/g, "$1").trim());
+        return `<${args.map(({ type, name }) => (type.includes("...") ? `${name}...` : name)).join(", ")}>`;
+    };
+
+    const hasTemplate = method.returnType.includes("template");
+    return `    ${hasTemplate ? "" : "template<typename = void> "}${method.returnType} ${method.name}(${method.params
+        .map(({ type, name }) => `${type} ${name}`)
+        .join(", ")}) ${method.modifiers} { return __o_.${method.name}${processTemplate(method.returnType)}(${method.params
+        .map(processArg)
+        .join(", ")}); }`;
+};
+
+const forward = (methods) => {
+    return `#pragma once
+
+#define ${result["output"].replaceAll("/", "_").replaceAll(".h", "").toUpperCase()}_FORWARD(__o_) \\
+public: \\
+${methods.map(forwardMethod).join(" \\\n")} \\
+\\
+private:
+`;
+};
+
+fs.writeFileSync(result["output"], forward(methods));

--- a/gen/reflect/package-lock.json
+++ b/gen/reflect/package-lock.json
@@ -1,0 +1,288 @@
+{
+  "name": "reflect",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "yargs": "^17.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yargs": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+    }
+  }
+}

--- a/gen/reflect/package.json
+++ b/gen/reflect/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "reflect",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "GPL-3.0",
+  "dependencies": {
+    "yargs": "^17.4.0"
+  }
+}

--- a/initrd/programs/event_loop_thread_test.cpp
+++ b/initrd/programs/event_loop_thread_test.cpp
@@ -12,6 +12,8 @@ class TestObject final : public App::Object {
     APP_OBJECT(TestObject)
 
 public:
+    TestObject() {}
+
     virtual void initialize() {
         on_unchecked<App::ThemeChangeEvent>([](const App::ThemeChangeEvent&) {
             error_log("Got event!");

--- a/initrd/programs/graphics_test.cpp
+++ b/initrd/programs/graphics_test.cpp
@@ -6,15 +6,19 @@
 #include <liim/string.h>
 
 class TestWidget final : public App::Widget {
-    APP_OBJECT(TestWidget)
+    APP_WIDGET(App::Widget, TestWidget)
 
 public:
-    virtual void initialize() override {
+    TestWidget() {}
+
+    virtual void did_attach() override {
         auto font_file = Ext::try_map_file(RESOURCE_ROOT "/usr/share/font.ttf", PROT_READ, MAP_SHARED);
         assert(font_file);
 
         set_font(TTF::Font::try_create_from_buffer(move(*font_file)));
         assert(font());
+
+        App::Widget::did_attach();
     }
 
     virtual void render() override {

--- a/initrd/programs/png_test.cpp
+++ b/initrd/programs/png_test.cpp
@@ -8,9 +8,11 @@
 static SharedPtr<Bitmap> s_bitmap;
 
 class TestWidget final : public App::Widget {
-    APP_OBJECT(TestWidget)
+    APP_WIDGET(App::Widget, TestWidget)
 
 public:
+    TestWidget() {}
+
     virtual void render() override {
         auto renderer = get_renderer();
         renderer.fill_rect(sized_rect(), ColorValue::Black);

--- a/initrd/programs/rect_set_test.cpp
+++ b/initrd/programs/rect_set_test.cpp
@@ -5,9 +5,11 @@
 #include <graphics/renderer.h>
 
 class TestWidget final : public App::Widget {
-    APP_OBJECT(TestWidget)
+    APP_WIDGET(App::Widget, TestWidget)
 
 public:
+    TestWidget() {}
+
     virtual void render() override {
         auto renderer = get_renderer();
 

--- a/initrd/programs/tui_test.cpp
+++ b/initrd/programs/tui_test.cpp
@@ -5,17 +5,17 @@
 #include <tui/frame.h>
 
 class TestPanel final : public TUI::Frame {
-    APP_OBJECT(TestPanel)
+    APP_WIDGET(TUI::Frame, TestPanel)
 
 public:
     TestPanel(Color color, TextAlign alignment, TInput::TerminalRenderer::BoxStyle box_style, String text)
-        : m_color(color), m_alignment(alignment), m_text(move(text)) {
-        set_frame_color(m_color.invert());
-        set_box_style(box_style);
-        set_accepts_focus(true);
-    }
+        : m_color(color), m_alignment(alignment), m_box_style(box_style), m_text(move(text)) {}
 
-    virtual void initialize() {
+    virtual void did_attach() {
+        set_frame_color(m_color.invert());
+        set_box_style(m_box_style);
+        set_accepts_focus(true);
+
         on<App::MouseDownEvent>([this](const App::MouseDownEvent&) {
             set_frame_color(m_color);
             m_color = m_color.invert();
@@ -30,7 +30,7 @@ public:
             return true;
         });
 
-        TUI::Frame::initialize();
+        TUI::Frame::did_attach();
     }
 
     virtual Maybe<Point> cursor_position() override { return { relative_inner_rect().top_left() }; }
@@ -53,6 +53,7 @@ public:
 private:
     Color m_color;
     TextAlign m_alignment;
+    TInput::TerminalRenderer::BoxStyle m_box_style;
     String m_text;
 };
 

--- a/libs/libapp/CMakeLists.txt
+++ b/libs/libapp/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     terminal_widget.cpp
     text_label.cpp
     tree_view.cpp
+    view.cpp
     widget.cpp
     window_os_2.cpp
     window_sdl.cpp
@@ -37,5 +38,17 @@ if(${NATIVE_BUILD})
         target_compile_definitions(libapp PRIVATE "USE_SDL2=1")
     endif()
 endif()
+
+generate_interface(libapp libapp_base_widget_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/widget.h app/base/widget_interface.h)
+generate_interface(libapp libapp_base_widget_bridge_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/widget_bridge.h app/base/widget_bridge_interface.h)
+
+generate_interface(libapp libapp_base_view_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/view.h app/base/view_interface.h)
+generate_interface(libapp libapp_base_view_bridge_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/view_bridge.h app/base/view_bridge_interface.h)
+
+generate_interface(libapp libapp_base_terminal_widget_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/terminal_widget.h app/base/terminal_widget_interface.h)
+generate_interface(libapp libapp_base_terminal_widget_bridge_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/terminal_widget_bridge.h app/base/terminal_widget_bridge_interface.h)
+
+generate_interface(libapp libapp_base_scroll_component_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/scroll_component.h app/base/scroll_component_interface.h)
+generate_interface(libapp libapp_base_scroll_component_bridge_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/app/base/scroll_component_bridge.h app/base/scroll_component_bridge_interface.h)
 
 target_link_libraries(libapp PUBLIC libeventloop libgraphics libterminal libclipboard window_server_headers)

--- a/libs/libapp/application_os_2.cpp
+++ b/libs/libapp/application_os_2.cpp
@@ -3,10 +3,10 @@
 
 namespace App {
 void WindowServerClient::initialize() {
-    m_server = IPC::Endpoint::create(shared_from_this());
+    m_server = add<IPC::Endpoint>();
     m_server->set_dispatcher(shared_from_this());
 
-    auto socket = UnixSocket::create_connection(shared_from_this(), "/tmp/.window_server.socket");
+    auto socket = UnixSocket::create_connection(this, "/tmp/.window_server.socket");
     m_server->set_socket(move(socket));
 }
 

--- a/libs/libapp/base/scroll_component.cpp
+++ b/libs/libapp/base/scroll_component.cpp
@@ -5,15 +5,16 @@
 #include <math.h>
 
 namespace App::Base {
-ScrollComponent::ScrollComponent(Object& object, int scrollbar_width) : Component(object), m_scrollbar_width(scrollbar_width) {}
+ScrollComponent::ScrollComponent(Widget& widget, SharedPtr<ScrollComponentBridge> bridge) : m_widget(widget), m_bridge(move(bridge)) {}
 
 ScrollComponent::~ScrollComponent() {}
 
 Rect ScrollComponent::available_rect() {
+    auto scrollbar_width = this->scrollbar_width();
     return widget()
         .sized_rect()
         .translated(m_scroll_offset)
-        .shrinked(draw_vertical_scrollbar() ? m_scrollbar_width : 0, draw_horizontal_scrollbar() ? m_scrollbar_width : 0);
+        .shrinked(draw_vertical_scrollbar() ? scrollbar_width : 0, draw_horizontal_scrollbar() ? scrollbar_width : 0);
 }
 
 Rect ScrollComponent::total_rect() {
@@ -34,7 +35,7 @@ bool ScrollComponent::horizontally_scrollable() {
     return !!(m_scrollability & ScrollDirection::Horizontal) && total_rect().width() > widget().sized_rect().width();
 }
 
-void ScrollComponent::did_attach() {
+void ScrollComponent::initialize() {
     widget().intercept<MouseScrollEvent>({}, [this](const MouseScrollEvent& event) {
         m_scroll_offset.set_y(m_scroll_offset.y() + event.z() * 6);
         clamp_scroll_offset();

--- a/libs/libapp/button.cpp
+++ b/libs/libapp/button.cpp
@@ -4,7 +4,9 @@
 #include <graphics/renderer.h>
 
 namespace App {
-void Button::initialize() {
+Button::Button(String label) : m_label(move(label)) {}
+
+void Button::did_attach() {
     on<MouseDownEvent>([this](const MouseDownEvent& event) {
         if (event.left_button()) {
             m_did_mousedown = true;
@@ -22,7 +24,7 @@ void Button::initialize() {
         return false;
     });
 
-    return Widget::initialize();
+    return Widget::did_attach();
 }
 
 void Button::render() {

--- a/libs/libapp/context_menu.cpp
+++ b/libs/libapp/context_menu.cpp
@@ -31,7 +31,7 @@ void ContextMenu::add_menu_item(String name, Function<void()> hook) {
 
 Window& ContextMenu::ensure_window(Point p) {
     if (!m_window) {
-        m_window = ContextMenuWindow::create(shared_from_this(), p, *this);
+        m_window = ContextMenuWindow::create(this, p, *this);
         auto& main_widget = m_window->set_main_widget<App::Widget>();
         auto& layout = main_widget.set_layout_engine<App::VerticalFlexLayoutEngine>();
         layout.set_margins({ 0, 0, 0, 0 });

--- a/libs/libapp/icon_view.cpp
+++ b/libs/libapp/icon_view.cpp
@@ -5,7 +5,9 @@
 #include <graphics/renderer.h>
 
 namespace App {
-void IconView::initialize() {
+IconView::IconView() {}
+
+void IconView::did_attach() {
     on<MouseDownEvent>([this](const MouseDownEvent& event) {
         if (event.left_button()) {
             m_in_selection = true;
@@ -53,11 +55,13 @@ void IconView::initialize() {
         invalidate();
     });
 
-    View::initialize();
+    View::did_attach();
 }
 
+IconView::~IconView() {}
+
 void IconView::render() {
-    auto renderer = get_renderer();
+    auto renderer = ScrollComponent::get_renderer();
     renderer.clear_rect(sized_rect(), background_color());
 
     for (int r = 0; r < m_items.size(); r++) {
@@ -113,7 +117,7 @@ void IconView::rebuild_layout() {
 }
 
 void IconView::install_model_listeners(Model& model) {
-    model.on<ModelUpdateEvent>(*this, [this, &model](auto&) {
+    listen<ModelUpdateEvent>(model, [this, &model](auto&) {
         rebuild_layout();
     });
 

--- a/libs/libapp/include/app/application_os_2.h
+++ b/libs/libapp/include/app/application_os_2.h
@@ -7,6 +7,7 @@ class WindowServerClient final : public WindowServer::Server::MessageDispatcher 
     APP_OBJECT(WindowServerClient)
 
 public:
+    WindowServerClient() {}
     virtual void initialize() override;
 
     IPC::Endpoint& server() { return *m_server; }

--- a/libs/libapp/include/app/base/forward.h
+++ b/libs/libapp/include/app/base/forward.h
@@ -2,9 +2,14 @@
 
 namespace App::Base {
 class Application;
+class ScrollComponent;
+class ScrollComponentBridge;
 class TableView;
 class TerminalWidget;
-class Widget;
-class Window;
+class TerminalWidgetBridge;
 class View;
+class ViewBridge;
+class Widget;
+class WidgetBridge;
+class Window;
 }

--- a/libs/libapp/include/app/base/scroll_component.h
+++ b/libs/libapp/include/app/base/scroll_component.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <app/base/forward.h>
+#include <app/base/scroll_component_bridge.h>
+#include <app/base/scroll_component_interface.h>
 #include <eventloop/component.h>
 #include <graphics/forward.h>
 #include <graphics/point.h>
@@ -11,11 +13,15 @@ enum ScrollDirection {
     Vertiacal = 1 << 1,
 };
 
-class ScrollComponent : public Component {
-public:
-    explicit ScrollComponent(Object& object, int scrollbar_width);
-    virtual ~ScrollComponent() override;
+class ScrollComponent {
+    APP_BASE_SCROLL_COMPONENT_BRIDGE_INTERFACE_FORWARD(bridge())
 
+public:
+    explicit ScrollComponent(Widget& widget, SharedPtr<ScrollComponentBridge> bridge);
+    void initialize();
+    virtual ~ScrollComponent();
+
+    // os_2 reflect begin
     Rect available_rect();
     Point scroll_offset() { return m_scroll_offset; }
 
@@ -36,17 +42,19 @@ public:
     }
 
     Rect total_rect();
-
-protected:
-    virtual void did_attach() override;
+    // os_2 reflect end
 
 private:
-    Widget& widget() { return typed_object<Widget>(); }
+    ScrollComponentBridge& bridge() { return *m_bridge; }
+    const ScrollComponentBridge& bridge() const { return *m_bridge; }
+
+    Widget& widget() { return m_widget; }
     void clamp_scroll_offset();
 
     Point m_scroll_offset;
+    Widget& m_widget;
+    SharedPtr<ScrollComponentBridge> m_bridge;
     int m_scrollability { ScrollDirection::Vertiacal };
     int m_scrollbar_visibility { ScrollDirection::Horizontal | ScrollDirection::Vertiacal };
-    int m_scrollbar_width { 0 };
 };
 }

--- a/libs/libapp/include/app/base/scroll_component_bridge.h
+++ b/libs/libapp/include/app/base/scroll_component_bridge.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <app/base/scroll_component_bridge_interface.h>
+
+namespace App::Base {
+class ScrollComponentBridge {
+public:
+    virtual ~ScrollComponentBridge() {}
+
+    // os_2 reflect begin
+    virtual int scrollbar_width() const = 0;
+    // os_2 reflect end
+};
+}

--- a/libs/libapp/include/app/base/terminal_widget_bridge.h
+++ b/libs/libapp/include/app/base/terminal_widget_bridge.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <app/base/terminal_widget_bridge_interface.h>
+#include <graphics/forward.h>
+
+namespace App::Base {
+class TerminalWidgetBridge {
+public:
+    virtual ~TerminalWidgetBridge() {}
+
+    // os_2 reflect begin
+    virtual Point cell_position_of_mouse_coordinates(int mouse_x, int mouse_y) const = 0;
+    virtual Rect available_cells() const = 0;
+    // os_2 reflect end
+
+    virtual void invalidate_all_contents() = 0;
+};
+}

--- a/libs/libapp/include/app/base/view.h
+++ b/libs/libapp/include/app/base/view.h
@@ -1,49 +1,60 @@
 #pragma once
 
+#include <app/base/scroll_component.h>
+#include <app/base/view_bridge.h>
+#include <app/base/view_interface.h>
+#include <app/base/widget.h>
 #include <app/forward.h>
 #include <app/selection.h>
-#include <eventloop/component.h>
-#include <eventloop/event.h>
-#include <liim/function.h>
 
 APP_EVENT(App, ViewRootChanged, Event, (), (), ());
 APP_EVENT(App, ViewItemActivated, Event, (), ((ModelItem*, item)), ())
 
 namespace App::Base {
-class View : public Component {
+class View
+    : public Widget
+    , public ScrollComponent {
+    APP_OBJECT(View)
+
+    APP_EMITS(Widget, ViewRootChanged, ViewItemActivated)
+
+    APP_BASE_VIEW_BRIDGE_INTERFACE_FORWARD(bridge())
+
 public:
-    ~View();
+    virtual void initialize() override;
+    virtual ~View() override;
 
-    Model* model() { return m_model.get(); }
-    const Model* model() const { return m_model.get(); }
+    // os_2 reflect begin
+    App::Model* model() { return m_model.get(); }
+    const App::Model* model() const { return m_model.get(); }
 
-    void set_model(SharedPtr<Model> model);
+    void set_model(SharedPtr<App::Model> model);
 
-    ModelItem* hovered_item() const { return m_hovered_item; }
-    void set_hovered_item(ModelItem*);
+    App::ModelItem* hovered_item() const { return m_hovered_item; }
+    void set_hovered_item(App::ModelItem* item);
 
-    Selection& selection() { return m_selection; }
-    const Selection& selection() const { return m_selection; }
+    App::Selection& selection() { return m_selection; }
+    const App::Selection& selection() const { return m_selection; }
 
-    ModelItem* root_item() { return m_root_item; }
-    const ModelItem* root_item() const { return m_root_item; }
+    App::ModelItem* root_item() { return m_root_item; }
+    const App::ModelItem* root_item() const { return m_root_item; }
 
-    void set_root_item(ModelItem* item);
+    void set_root_item(App::ModelItem* item);
+    // os_2 reflect end
+
+    const ViewBridge& bridge() const { return *m_bridge; }
+    ViewBridge& bridge() { return *m_bridge; }
 
 protected:
-    explicit View(Object& object);
-
-    virtual void did_attach() override;
-    virtual void invalidate_all() = 0;
-    virtual ModelItem* item_at_position(const Point& point) = 0;
-
-    virtual void install_model_listeners(Model& model);
-    virtual void uninstall_model_listeners(Model& model);
-
-    Widget& this_widget() { return typed_object<Widget>(); }
+    explicit View(SharedPtr<WidgetBridge> widget_bridge, SharedPtr<ViewBridge> view_bridge,
+                  SharedPtr<ScrollComponentBridge> scroll_component_bridge);
 
 private:
+    void install_model_listeners(Model& model);
+    void uninstall_model_listeners(Model& model);
+
     SharedPtr<Model> m_model;
+    SharedPtr<ViewBridge> m_bridge;
     ModelItem* m_hovered_item;
     Selection m_selection;
     ModelItem* m_root_item { nullptr };

--- a/libs/libapp/include/app/base/view_bridge.h
+++ b/libs/libapp/include/app/base/view_bridge.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <app/base/view_bridge_interface.h>
+#include <app/forward.h>
+#include <graphics/forward.h>
+
+namespace App::Base {
+class ViewBridge {
+public:
+    virtual ~ViewBridge() {}
+
+    // os_2 reflect begin
+    virtual ModelItem* item_at_position(const Point& point) = 0;
+    // os_2 reflect end
+
+    virtual void invalidate_all() = 0;
+
+    virtual void install_model_listeners(Model&) {}
+    virtual void uninstall_model_listeners(Model&) {}
+};
+}

--- a/libs/libapp/include/app/base/widget_bridge.h
+++ b/libs/libapp/include/app/base/widget_bridge.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <app/base/widget_bridge_interface.h>
+#include <eventloop/forward.h>
+#include <graphics/point.h>
+#include <liim/maybe.h>
+
+#define APP_WIDGET_BASE_IMPL(BaseType, ParentType, Self, ...)                                  \
+public:                                                                                        \
+    using BaseWidget = BaseType;                                                               \
+                                                                                               \
+protected:                                                                                     \
+    static SharedPtr<BaseType> create_base_object(App::Object* object, SharedPtr<Self> self) { \
+        return BaseWidget::create_without_initializing(object, ##__VA_ARGS__);                 \
+    }                                                                                          \
+                                                                                               \
+public:                                                                                        \
+    BaseWidget& base() { return typed_object<BaseWidget>(); }                                  \
+    const BaseWidget& base() const { return typed_object<BaseWidget>(); }                      \
+                                                                                               \
+private:
+
+#define APP_WIDGET_IMPL_NO_BASE(ParentType)    \
+public:                                        \
+    using BaseWidget = ParentType::BaseWidget; \
+                                               \
+private:
+
+#define APP_WIDGET_IMPL(ParentType, Self)                                                                                  \
+public:                                                                                                                    \
+    using ParentWidget = ParentType;                                                                                       \
+                                                                                                                           \
+    Self(const Self&) = delete;                                                                                            \
+    Self(Self&&) = delete;                                                                                                 \
+                                                                                                                           \
+    template<typename... Args>                                                                                             \
+    static App::Base::WidgetCreationResultOwned<BaseWidget, Self> create_both_owned(App::Object* parent, Args&&... args) { \
+        auto custom = make_shared<Self>(forward<Args>(args)...);                                                           \
+        auto base = create_base_object(parent, custom);                                                                    \
+        custom->attach(*base);                                                                                             \
+        base->initialize();                                                                                                \
+        return { base, custom };                                                                                           \
+    }                                                                                                                      \
+                                                                                                                           \
+    template<typename... Args>                                                                                             \
+    static SharedPtr<BaseWidget> create_base_owned(App::Object* parent, Args&&... args) {                                  \
+        return create_both_owned(parent, forward<Args>(args)...).base;                                                     \
+    }                                                                                                                      \
+                                                                                                                           \
+    template<typename... Args>                                                                                             \
+    static SharedPtr<Self> create_owned(App::Object* parent, Args&&... args) {                                             \
+        assert(parent);                                                                                                    \
+        return create_both_owned(parent, forward<Args>(args)...).custom;                                                   \
+    }                                                                                                                      \
+                                                                                                                           \
+    template<typename... Args>                                                                                             \
+    static App::Base::WidgetCreationResultRef<BaseWidget, Self> create_both(App::Object* parent, Args&&... args) {         \
+        return *create_both_owned(parent, forward<Args>(args)...);                                                         \
+    }                                                                                                                      \
+                                                                                                                           \
+    template<typename... Args>                                                                                             \
+    static BaseWidget& create_base(App::Object* parent, Args&&... args) {                                                  \
+        return *create_both_owned(parent, forward<Args>(args)...).base;                                                    \
+    }                                                                                                                      \
+                                                                                                                           \
+    template<typename... Args>                                                                                             \
+    static Self& create(App::Object* parent, Args&&... args) {                                                             \
+        return *create_both_owned(parent, forward<Args>(args)...).custom;                                                  \
+    }                                                                                                                      \
+                                                                                                                           \
+private:
+
+#define APP_WIDGET_EMITS_IMPL(...)                                                                                                     \
+public:                                                                                                                                \
+    template<typename... Ev>                                                                                                           \
+    static constexpr bool does_emit() {                                                                                                \
+        return (LIIM::IsOneOf<Ev, ##__VA_ARGS__>::value && ...) || ParentWidget::does_emit<Ev...>() || BaseWidget::does_emit<Ev...>(); \
+    }                                                                                                                                  \
+                                                                                                                                       \
+private:
+
+#define APP_WIDGET_BASE(BaseType, ParentType, Self, ...)            \
+    APP_WIDGET_BASE_IMPL(BaseType, ParentType, Self, ##__VA_ARGS__) \
+    APP_WIDGET_IMPL(ParentType, Self)                               \
+    APP_OBJECT_FORWARD_EVENT_API(base())                            \
+    APP_WIDGET_EMITS_IMPL()
+
+#define APP_WIDGET_BASE_EMITS(BaseType, ParentType, Self, Emits, ...) \
+    APP_WIDGET_BASE_IMPL(BaseType, ParentType, Self, ##__VA_ARGS__)   \
+    APP_WIDGET_IMPL(ParentType, Self)                                 \
+    APP_OBJECT_FORWARD_EVENT_API(base())                              \
+    APP_WIDGET_EMITS_IMPL EMITS
+
+#define APP_WIDGET(ParentType, Self)     \
+    APP_WIDGET_IMPL_NO_BASE(ParentType)  \
+    APP_WIDGET_IMPL(ParentType, Self)    \
+    APP_OBJECT_FORWARD_EVENT_API(base()) \
+    APP_WIDGET_EMITS_IMPL()
+
+#define APP_WIDGET_EMITS(ParentType, Self, Emits) \
+    APP_WIDGET_IMPL_NO_BASE(ParentType)           \
+    APP_WIDGET_IMPL(ParentType, Self)             \
+    APP_OBJECT_FORWARD_EVENT_API(base())          \
+    APP_WIDGET_EMITS_IMPL Emits
+
+namespace App::Base {
+template<typename BaseWidget, typename CustomWidget>
+struct WidgetCreationResultRef {
+    BaseWidget& base;
+    CustomWidget& custom;
+};
+
+template<typename BaseWidget, typename CustomWidget>
+struct WidgetCreationResultOwned {
+    SharedPtr<BaseWidget> base;
+    SharedPtr<CustomWidget> custom;
+
+    WidgetCreationResultRef<BaseWidget, CustomWidget> operator*() { return { *base, *custom }; }
+};
+
+class WidgetBridge {
+public:
+    template<typename... Ev>
+    static constexpr bool does_emit() {
+        return false;
+    }
+
+    virtual ~WidgetBridge() {}
+
+    // os_2 reflect begin
+    virtual bool steals_focus() { return false; }
+
+    virtual Maybe<Point> cursor_position() { return {}; }
+    // os_2 reflect end
+
+    virtual void render() {}
+
+private:
+    Object* m_object { nullptr };
+};
+}

--- a/libs/libapp/include/app/base/window.h
+++ b/libs/libapp/include/app/base/window.h
@@ -37,13 +37,14 @@ public:
 
     template<typename T, typename... Args>
     T& set_main_widget(Args... args) {
-        auto ret = T::create(shared_from_this(), forward<Args>(args)...);
-        ret->set_positioned_rect(rect());
-        set_focused_widget(ret.get());
+        auto [result_base, result] = T::create_both_owned(this, forward<Args>(args)...);
+        result_base->set_positioned_rect(rect());
+        set_focused_widget(result_base.get());
         invalidate_rect(rect());
-        m_main_widget = ret;
-        return *ret;
+        m_main_widget = move(result_base);
+        return *result;
     }
+
     Widget& main_widget() { return *m_main_widget; }
     const Widget& main_widget() const { return *m_main_widget; }
 

--- a/libs/libapp/include/app/button.h
+++ b/libs/libapp/include/app/button.h
@@ -9,18 +9,15 @@ APP_EVENT(App, ClickEvent, Event, (), (), ())
 
 namespace App {
 class Button : public Widget {
-    APP_OBJECT(Button)
-
-    APP_EMITS(Widget, ClickEvent)
+    APP_WIDGET_EMITS(Widget, Button, (ClickEvent))
 
 public:
-    explicit Button(String label) : m_label(move(label)) { set_accepts_focus(true); }
-    virtual void initialize() override;
+    explicit Button(String label);
+    virtual void did_attach() override;
 
     void set_label(String label) { m_label = move(label); }
     const String& label() const { return m_label; }
 
-private:
     virtual void render() override;
 
     String m_label;

--- a/libs/libapp/include/app/icon_view.h
+++ b/libs/libapp/include/app/icon_view.h
@@ -8,10 +8,13 @@
 namespace App {
 
 class IconView : public View {
-    APP_OBJECT(IconView)
+    APP_WIDGET(View, IconView)
 
 public:
-    virtual void initialize() override;
+    IconView();
+    virtual void did_attach() override;
+    virtual ~IconView() override;
+
     virtual void render() override;
 
     void set_name_column(int col) { m_name_column = col; }

--- a/libs/libapp/include/app/layout_engine.h
+++ b/libs/libapp/include/app/layout_engine.h
@@ -32,12 +32,20 @@ public:
     void set_margins(const Margins& m) { m_margins = m; }
     const Margins& margins() const { return m_margins; }
 
-    template<typename PanelType, typename... Args>
-    PanelType& add(Args&&... args) {
-        auto panel = PanelType::create(parent().shared_from_this(), forward<Args>(args)...);
-        do_add(*panel);
+    template<typename WidgetType, typename... Args>
+    WidgetType& add(Args&&... args) {
+        auto& result = WidgetType::create(&parent(), forward<Args>(args)...);
+        do_add(result.base());
         schedule_layout();
-        return *panel;
+        return result;
+    }
+
+    template<typename WidgetType, typename... Args>
+    SharedPtr<WidgetType> add_owned(Args&&... args) {
+        auto result = WidgetType::create_owned(&parent(), forward<Args>(args)...);
+        do_add(result->base());
+        schedule_layout();
+        return result;
     }
 
     void remove(Base::Widget& child) {

--- a/libs/libapp/include/app/menubar.h
+++ b/libs/libapp/include/app/menubar.h
@@ -6,11 +6,11 @@
 
 namespace App {
 class Menubar : public Widget {
-    APP_OBJECT(Menubar)
+    APP_WIDGET(Widget, Menubar)
 
 public:
     Menubar();
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~Menubar() override;
 
     ContextMenu& create_menu(String name);

--- a/libs/libapp/include/app/scroll_component.h
+++ b/libs/libapp/include/app/scroll_component.h
@@ -7,17 +7,32 @@
 #include <graphics/point.h>
 
 namespace App {
-class ScrollComponent : public Base::ScrollComponent {
-public:
-    static constexpr int scrollbar_width = 16;
+class ScrollComponent : public Base::ScrollComponentBridge {
+    APP_BASE_SCROLL_COMPONENT_INTERFACE_FORWARD(base())
 
-    explicit ScrollComponent(Object& object);
+public:
+    static constexpr int s_scrollbar_width = 16;
+
+    explicit ScrollComponent(Widget& widget);
     virtual ~ScrollComponent() override;
+
+    void attach_to_base(Base::ScrollComponent& base);
+
+    virtual int scrollbar_width() const override { return s_scrollbar_width; }
 
     Renderer get_renderer();
     void draw_scrollbars();
 
 private:
-    Widget& widget() { return typed_object<Widget>(); }
+    void did_attach();
+
+    Base::ScrollComponent& base() { return *m_base; }
+    const Base::ScrollComponent& base() const { return *m_base; }
+
+    Widget& widget() { return m_widget; }
+    const Widget& widget() const { return m_widget; }
+
+    Widget& m_widget;
+    Base::ScrollComponent* m_base { nullptr };
 };
 }

--- a/libs/libapp/include/app/tab_widget.h
+++ b/libs/libapp/include/app/tab_widget.h
@@ -7,26 +7,27 @@
 namespace App {
 
 class TabWidget : public Widget {
-    APP_OBJECT(TabWidget)
+    APP_WIDGET(Widget, TabWidget)
 
 public:
-    virtual void initialize() override;
+    TabWidget() {}
+    virtual void did_attach() override;
     virtual void render() override;
 
     template<typename T, typename... Args>
     T& add_tab(String name, Args... args) {
-        auto ret = T::create(shared_from_this(), forward<Args>(args)...);
+        auto& widget = create_widget<T>(forward<Args>(args)...);
         if (active_tab() != -1 && m_tabs.size() != active_tab()) {
-            ret->set_hidden(true);
+            widget.set_hidden(true);
         } else if (active_tab() == -1) {
-            ret->set_hidden(false);
+            widget.set_hidden(false);
             m_active_tab = m_tabs.size();
         }
-        ret->set_positioned_rect(tab_content_rect());
+        widget.set_positioned_rect(tab_content_rect());
 
         auto rect = next_tab_rect(name);
-        m_tabs.add({ move(name), rect, ret });
-        return *ret;
+        m_tabs.add({ move(name), rect, widget.base().shared_from_this() });
+        return widget;
     }
 
     void remove_tab(int index);
@@ -37,7 +38,7 @@ public:
     const Rect& tab_content_rect() const { return m_tab_content_rect; }
 
 protected:
-    virtual void did_remove_child(SharedPtr<Object>) override;
+    // virtual void did_remove_child(SharedPtr<Object>) override;
 
     Rect next_tab_rect(const String& name) const;
 
@@ -45,7 +46,7 @@ private:
     struct Tab {
         String name;
         Rect rect;
-        SharedPtr<Widget> widget;
+        SharedPtr<Base::Widget> widget;
     };
 
     Vector<Tab> m_tabs;

--- a/libs/libapp/include/app/table_view.h
+++ b/libs/libapp/include/app/table_view.h
@@ -6,9 +6,10 @@
 
 namespace App {
 class TableView : public View {
-    APP_OBJECT(TableView)
+    APP_WIDGET(View, TableView)
 
 public:
+    TableView() {}
     virtual ~TableView() override;
 
     virtual void render() override;

--- a/libs/libapp/include/app/terminal_widget.h
+++ b/libs/libapp/include/app/terminal_widget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <app/base/terminal_widget.h>
+#include <app/base/terminal_widget_bridge.h>
 #include <app/widget.h>
 #include <eventloop/selectable.h>
 #include <liim/pointers.h>
@@ -8,19 +9,19 @@
 namespace App {
 class TerminalWidget final
     : public Widget
-    , public Base::TerminalWidget {
-    APP_OBJECT(TerminalWidget)
+    , public Base::TerminalWidgetBridge {
+    APP_WIDGET_BASE(Base::TerminalWidget, Widget, TerminalWidget, self, self)
 
-    APP_EMITS(Widget, TerminalHangupEvent)
+    APP_BASE_TERMINAL_WIDGET_INTERFACE_FORWARD(base())
 
 public:
     explicit TerminalWidget(double opacity);
-    virtual void initialize() override;
+    virtual void did_attach() override;
 
     // ^App::Widget
     virtual void render() override;
 
-    // ^Base::TerminalWidget
+    // ^Base::TerminalWidgetBridge
     virtual void invalidate_all_contents() override { invalidate(); }
     virtual Point cell_position_of_mouse_coordinates(int mouse_x, int mouse_y) const override;
     virtual Rect available_cells() const override;

--- a/libs/libapp/include/app/text_label.h
+++ b/libs/libapp/include/app/text_label.h
@@ -7,7 +7,7 @@
 namespace App {
 
 class TextLabel : public Widget {
-    APP_OBJECT(TextLabel)
+    APP_WIDGET(Widget, TextLabel)
 
 public:
     TextLabel(String text) : m_text(move(text)) {}

--- a/libs/libapp/include/app/tree_view.h
+++ b/libs/libapp/include/app/tree_view.h
@@ -4,14 +4,12 @@
 #include <app/view.h>
 
 namespace App {
-class TreeView
-    : public View
-    , public ScrollComponent {
-    APP_OBJECT(TreeView)
+class TreeView : public View {
+    APP_WIDGET(View, TreeView)
 
 public:
-    TreeView() : ScrollComponent(static_cast<Object&>(*this)) {}
-    virtual void initialize() override;
+    TreeView() {}
+    virtual void did_attach() override;
     virtual void render() override;
 
     void set_name_column(int col) { m_name_column = col; }

--- a/libs/libapp/include/app/view.h
+++ b/libs/libapp/include/app/view.h
@@ -1,22 +1,28 @@
 #pragma once
 
 #include <app/base/view.h>
+#include <app/base/view_bridge.h>
 #include <app/forward.h>
+#include <app/scroll_component.h>
 #include <app/widget.h>
 
 namespace App {
 class View
     : public Widget
-    , public Base::View {
-    APP_OBJECT(View)
+    , public Base::ViewBridge
+    , public ScrollComponent {
+    APP_WIDGET_BASE(Base::View, Widget, View, self, self, self)
 
-    APP_EMITS(Widget, ViewRootChanged, ViewItemActivated)
+    APP_BASE_VIEW_INTERFACE_FORWARD(base())
+
+public:
+    virtual void did_attach() override;
 
 protected:
-    View() : Base::View(static_cast<Object&>(*this)) {}
+    View();
 
 private:
-    // ^Base::View
-    virtual void invalidate_all() override { invalidate(); }
+    // ^Base::ViewBridge
+    virtual void invalidate_all() override;
 };
 }

--- a/libs/libapp/include/app/widget.h
+++ b/libs/libapp/include/app/widget.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <app/base/widget.h>
+#include <app/base/widget_bridge.h>
 #include <app/forward.h>
+#include <eventloop/component.h>
 #include <eventloop/forward.h>
 #include <graphics/color.h>
 #include <graphics/font.h>
@@ -10,11 +12,18 @@
 #include <graphics/rect.h>
 
 namespace App {
-class Widget : public Base::Widget {
-    APP_OBJECT(Widget)
+class Widget
+    : public Component
+    , public Base::WidgetBridge {
+    APP_WIDGET_BASE(Base::Widget, Base::WidgetBridge, Widget, self)
+
+    APP_OBJECT_FORWARD_API(base())
+
+    APP_BASE_WIDGET_INTERFACE_FORWARD(base())
 
 public:
-    virtual void initialize() override;
+    Widget();
+    virtual void did_attach() override;
     virtual ~Widget() override;
 
     SharedPtr<Font> font() const { return m_font; }
@@ -22,8 +31,7 @@ public:
 
     void set_context_menu(SharedPtr<ContextMenu> menu);
 
-    Widget* parent_widget() { return static_cast<Widget*>(Base::Widget::parent_widget()); }
-    Window* parent_window();
+    Window* typed_parent_window();
 
     Color background_color() const { return m_palette->color(Palette::Background); }
     Color text_color() const { return m_palette->color(Palette::Text); }
@@ -33,9 +41,6 @@ public:
 
     Renderer get_renderer();
 
-protected:
-    Widget();
-
 private:
     virtual bool is_widget() const final { return true; }
 
@@ -43,5 +48,4 @@ private:
     SharedPtr<Palette> m_palette;
     SharedPtr<ContextMenu> m_context_menu;
 };
-
 }

--- a/libs/libapp/scroll_component.cpp
+++ b/libs/libapp/scroll_component.cpp
@@ -1,10 +1,13 @@
+#include <app/base/widget.h>
 #include <app/scroll_component.h>
 #include <app/widget.h>
 #include <graphics/renderer.h>
 #include <math.h>
 
 namespace App {
-ScrollComponent::ScrollComponent(Object& object) : Base::ScrollComponent(object, scrollbar_width) {}
+ScrollComponent::ScrollComponent(Widget& widget) : m_widget(widget) {}
+
+void ScrollComponent::did_attach() {}
 
 ScrollComponent::~ScrollComponent() {}
 
@@ -17,6 +20,7 @@ Renderer ScrollComponent::get_renderer() {
 
 void ScrollComponent::draw_scrollbars() {
     auto renderer = widget().get_renderer();
+    auto scrollbar_width = this->scrollbar_width();
 
     if (draw_horizontal_scrollbar()) {
         renderer.fill_rect({ 0, widget().sized_rect().height() - scrollbar_width, widget().sized_rect().width(), scrollbar_width },
@@ -53,5 +57,10 @@ void ScrollComponent::draw_scrollbars() {
             },
             ColorValue::White);
     }
+}
+
+void ScrollComponent::attach_to_base(Base::ScrollComponent& base) {
+    m_base = &base;
+    did_attach();
 }
 }

--- a/libs/libapp/tab_widget.cpp
+++ b/libs/libapp/tab_widget.cpp
@@ -5,7 +5,6 @@
 #include <graphics/renderer.h>
 
 namespace App {
-
 constexpr int character_height = 16;
 constexpr int character_width = 8;
 
@@ -14,7 +13,7 @@ constexpr int tab_border = 1;
 constexpr int tab_bar_height = 2 * (tab_border + tab_padding) + character_height;
 constexpr int tab_bar_left_margin = 4;
 
-void TabWidget::initialize() {
+void TabWidget::did_attach() {
     on<MouseDownEvent>([this](const MouseDownEvent& event) {
         if (event.left_button()) {
             for (int i = 0; i < m_tabs.size(); i++) {
@@ -30,7 +29,7 @@ void TabWidget::initialize() {
     // FIXME: use some sort of focus proxy mechanism instead.
     on<FocusedEvent>([this](const FocusedEvent&) {
         if (m_active_tab != -1) {
-            parent_window()->set_focused_widget(m_tabs[m_active_tab].widget.get());
+            m_tabs[m_active_tab].widget->make_focused();
         }
     });
 
@@ -46,7 +45,7 @@ void TabWidget::initialize() {
         m_tab_content_rect = tab_content_rect;
     });
 
-    Widget::initialize();
+    Widget::did_attach();
 }
 
 void TabWidget::render() {
@@ -73,7 +72,7 @@ void TabWidget::set_active_tab(int index) {
     m_active_tab = index;
     if (m_active_tab != -1) {
         m_tabs[m_active_tab].widget->set_hidden(false);
-        parent_window()->set_focused_widget(m_tabs[m_active_tab].widget.get());
+        m_tabs[m_active_tab].widget->make_focused();
     }
 }
 
@@ -94,16 +93,18 @@ void TabWidget::remove_tab(int index) {
     }
 }
 
+/*
 void TabWidget::did_remove_child(SharedPtr<Object> child) {
     int i = 0;
     for (auto& tab : m_tabs) {
-        if (tab.widget.get() == child.get()) {
+        if (&tab.widget->base() == child.get()) {
             remove_tab(i);
             break;
         }
         i++;
     }
 }
+*/
 
 Rect TabWidget::next_tab_rect(const String& name) const {
     auto text_width = static_cast<int>(name.size()) * character_width;
@@ -116,5 +117,4 @@ Rect TabWidget::next_tab_rect(const String& name) const {
     auto& reference_rect = m_tabs.last().rect;
     return { reference_rect.x() + reference_rect.width(), 0, width, tab_bar_height };
 }
-
 }

--- a/libs/libapp/table_view.cpp
+++ b/libs/libapp/table_view.cpp
@@ -44,7 +44,7 @@ void TableView::render() {
         return;
     }
 
-    auto renderer = get_renderer();
+    auto renderer = ScrollComponent::get_renderer();
     renderer.fill_rect(sized_rect(), background_color());
 
     auto field_count = model()->field_count();

--- a/libs/libapp/terminal_widget.cpp
+++ b/libs/libapp/terminal_widget.cpp
@@ -14,11 +14,10 @@ namespace App {
 constexpr int cell_width = 8;
 constexpr int cell_height = 16;
 
-TerminalWidget::TerminalWidget(double opacity)
-    : Base::TerminalWidget(static_cast<Object&>(*this)), m_background_alpha(static_cast<uint8_t>(opacity * 255)) {}
+TerminalWidget::TerminalWidget(double opacity) : m_background_alpha(static_cast<uint8_t>(opacity * 255)) {}
 
-void TerminalWidget::initialize() {
-    auto context_menu = App::ContextMenu::create(parent_window()->shared_from_this(), parent_window()->shared_from_this());
+void TerminalWidget::did_attach() {
+    auto context_menu = App::ContextMenu::create(parent_window(), parent_window()->shared_from_this());
     context_menu->add_menu_item("Copy", [this] {
         this->copy_selection();
     });
@@ -27,7 +26,7 @@ void TerminalWidget::initialize() {
     });
     set_context_menu(move(context_menu));
 
-    Widget::initialize();
+    Widget::did_attach();
 }
 
 Point TerminalWidget::cell_position_of_mouse_coordinates(int mouse_x, int mouse_y) const {

--- a/libs/libapp/tree_view.cpp
+++ b/libs/libapp/tree_view.cpp
@@ -3,7 +3,7 @@
 #include <graphics/renderer.h>
 
 namespace App {
-void TreeView::initialize() {
+void TreeView::did_attach() {
     on<ResizeEvent>([this](auto&) {
         rebuild_layout();
     });
@@ -26,7 +26,7 @@ void TreeView::initialize() {
         return false;
     });
 
-    View::initialize();
+    View::did_attach();
 }
 
 void TreeView::render() {
@@ -78,7 +78,7 @@ TreeView::Item* TreeView::internal_item_at_position(const Point& point) {
 }
 
 void TreeView::install_model_listeners(Model& model) {
-    model.on<ModelUpdateEvent>(*this, [this, &model](auto&) {
+    listen<ModelUpdateEvent>(model, [this, &model](auto&) {
         rebuild_items();
     });
 

--- a/libs/libapp/view.cpp
+++ b/libs/libapp/view.cpp
@@ -1,0 +1,14 @@
+#include <app/base/view.h>
+#include <app/view.h>
+
+namespace App {
+View::View() : ScrollComponent(static_cast<Widget&>(*this)) {}
+
+void View::did_attach() {
+    ScrollComponent::attach_to_base(base());
+}
+
+void View::invalidate_all() {
+    invalidate();
+}
+}

--- a/libs/libapp/widget.cpp
+++ b/libs/libapp/widget.cpp
@@ -1,4 +1,5 @@
 #include <app/application.h>
+#include <app/base/widget.h>
 #include <app/context_menu.h>
 #include <app/layout_engine.h>
 #include <app/widget.h>
@@ -11,7 +12,7 @@
 namespace App {
 Widget::Widget() : m_palette(Application::the().palette()) {}
 
-void Widget::initialize() {
+void Widget::did_attach() {
     on<MouseDownEvent>([this](const MouseDownEvent& event) {
         if (!m_context_menu) {
             return false;
@@ -23,14 +24,12 @@ void Widget::initialize() {
         }
         return false;
     });
-
-    Base::Widget::initialize();
 }
 
 Widget::~Widget() {}
 
-Window* Widget::parent_window() {
-    return static_cast<Window*>(Base::Widget::parent_window());
+Window* Widget::typed_parent_window() {
+    return static_cast<Window*>(parent_window());
 }
 
 void Widget::set_context_menu(SharedPtr<ContextMenu> menu) {
@@ -38,7 +37,7 @@ void Widget::set_context_menu(SharedPtr<ContextMenu> menu) {
 }
 
 Renderer Widget::get_renderer() {
-    Renderer renderer(*parent_window()->pixels());
+    Renderer renderer(*typed_parent_window()->pixels());
     renderer.set_bounding_rect(positioned_rect());
     return renderer;
 }

--- a/libs/libapp/window.cpp
+++ b/libs/libapp/window.cpp
@@ -128,7 +128,7 @@ void Window::set_current_context_menu(ContextMenu* menu) {
 
 void Window::do_render() {
     if (!main_widget().hidden()) {
-        main_widget().render();
+        main_widget().render_including_children();
         m_platform_window->flush_pixels();
         clear_dirty_rects();
     }

--- a/libs/libclipboard/connection.cpp
+++ b/libs/libclipboard/connection.cpp
@@ -9,7 +9,7 @@ static IPC::Endpoint& endpoint() {
     static SharedPtr<IPC::Endpoint> endpoint;
     if (!endpoint) {
         endpoint = IPC::Endpoint::create(nullptr);
-        endpoint->set_socket(App::UnixSocket::create_connection(endpoint, "/tmp/.clipboard_server.socket"));
+        endpoint->set_socket(App::UnixSocket::create_connection(endpoint.get(), "/tmp/.clipboard_server.socket"));
     }
     return *endpoint;
 }

--- a/libs/libedit/CMakeLists.txt
+++ b/libs/libedit/CMakeLists.txt
@@ -17,4 +17,7 @@ set(SOURCES
 
 add_os_library(libedit edit TRUE)
 
-target_link_libraries(libedit PUBLIC libliim libext libgraphics libeventloop libthread libclanguage libsh)
+generate_interface(libedit libedit_display_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/edit/display.h edit/display_interface.h)
+generate_interface(libedit libedit_display_bridge_interface ${CMAKE_CURRENT_SOURCE_DIR}/include/edit/display_bridge.h edit/display_bridge_interface.h)
+
+target_link_libraries(libedit PUBLIC libapp libliim libext libgraphics libeventloop libthread libclanguage libsh)

--- a/libs/libedit/actions.cpp
+++ b/libs/libedit/actions.cpp
@@ -2,6 +2,7 @@
 #include <edit/display.h>
 #include <edit/document.h>
 #include <edit/keyboard_action.h>
+#include <edit/rendered_line.h>
 
 namespace Edit {
 void init_actions() {
@@ -305,10 +306,10 @@ void init_actions() {
     });
 
     register_display_keyboard_action("New Display", { App::Key::N, App::KeyModifier::Control }, [](Display& display) {
-        display.object().emit<Edit::NewDisplayEvent>();
+        display.emit<Edit::NewDisplayEvent>();
     });
     register_display_keyboard_action("Split Display", { App::Key::Backslash, App::KeyModifier::Control }, [](Display& display) {
-        display.object().emit<Edit::SplitDisplayEvent>();
+        display.emit<Edit::SplitDisplayEvent>();
     });
 
     register_display_keyboard_action("Search", { App::Key::F, App::KeyModifier::Control }, [](Display& display) {
@@ -317,7 +318,7 @@ void init_actions() {
     });
 
     register_display_keyboard_action("Go To Line", { App::Key::G, App::KeyModifier::Control }, [](Display& display) {
-        display.object().start_coroutine(display.go_to_line());
+        display.start_coroutine(display.go_to_line());
     });
 
     register_display_keyboard_action("Toogle Show Line Numbers", { App::Key::L, App::KeyModifier::Alt }, [](Display& display) {
@@ -329,14 +330,14 @@ void init_actions() {
     });
 
     register_display_keyboard_action("Open File", { App::Key::O, App::KeyModifier::Control }, [](Display& display) {
-        display.object().start_coroutine(display.do_open_prompt());
+        display.start_coroutine(display.do_open_prompt());
     });
     register_display_keyboard_action("Close Display", { App::Key::Q, App::KeyModifier::Control }, [](Display& display) {
-        display.object().start_coroutine(display.quit());
+        display.start_coroutine(display.quit());
     });
 
     register_display_keyboard_action("Save", { App::Key::S, App::KeyModifier::Control }, [](Display& display) {
-        display.object().start_coroutine(display.save());
+        display.start_coroutine(display.save());
     });
 }
 }

--- a/libs/libedit/document.cpp
+++ b/libs/libedit/document.cpp
@@ -800,7 +800,7 @@ void Document::copy(Display& display, MultiCursor& cursors) {
         return;
     }
 
-    display.set_clipboard_contents(cursor.selection_text(*this));
+    display.set_clipboard_contents(cursor.selection_text(*this), false);
 }
 
 void Document::cut(Display& display, MultiCursor& cursors) {
@@ -815,7 +815,7 @@ void Document::cut(Display& display, MultiCursor& cursors) {
         return;
     }
 
-    display.set_clipboard_contents(cursor.selection_text(*this));
+    display.set_clipboard_contents(cursor.selection_text(*this), false);
     push_command<DeleteCommand>(display);
 }
 

--- a/libs/libedit/include/edit/display_bridge.h
+++ b/libs/libedit/include/edit/display_bridge.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <edit/display_bridge_interface.h>
+#include <edit/forward.h>
+#include <eventloop/forward.h>
+#include <liim/forward.h>
+
+namespace Edit {
+class DisplayBridge {
+public:
+    virtual ~DisplayBridge() {}
+
+    // os_2 reflect begin
+    virtual int rows() const = 0;
+    virtual int cols() const = 0;
+
+    virtual Edit::TextIndex text_index_at_mouse_position(const Point& point) = 0;
+    virtual Edit::RenderedLine compose_line(const Edit::Line& line) = 0;
+    virtual void output_line(int row, int col_offset, const Edit::RenderedLine& line, int line_index) = 0;
+    virtual void invalidate_all_line_rects() = 0;
+    virtual void invalidate_line_rect(int row_in_display) = 0;
+    virtual int enter() = 0;
+    virtual void send_status_message(String message) = 0;
+    virtual Task<Maybe<String>> prompt(String message, String initial_value);
+    virtual void enter_search(String starting_text) = 0;
+
+    virtual void do_compute_suggestions() {}
+    virtual void show_suggestions_panel() {}
+    virtual void hide_suggestions_panel() {}
+
+    virtual App::ObjectBoundCoroutine do_open_prompt() = 0;
+    virtual App::ObjectBoundCoroutine quit() = 0;
+
+    virtual void set_clipboard_contents(LIIM::String text, bool is_whole_line) = 0;
+    virtual String clipboard_contents(bool& is_whole_line) const = 0;
+    // os_2 reflect end
+
+    // FIXME: these should be proper events
+    virtual void document_did_change() {}
+    virtual void suggestions_did_change(const Maybe<TextRange>&) {}
+    virtual void did_set_show_line_numbers() {}
+
+    virtual void install_document_listeners(Document&) {}
+    virtual void uninstall_document_listeners(Document&) {}
+};
+}

--- a/libs/libedit/include/edit/forward.h
+++ b/libs/libedit/include/edit/forward.h
@@ -7,19 +7,20 @@ class AbsolutePosition;
 class CharacterMetadata;
 class Command;
 class Cursor;
-class DisplayPosition;
 class Display;
+class DisplayBridge;
+class DisplayPosition;
 class Document;
-class LineRenderer;
 class Line;
+class LineRenderer;
 class MatchedSuggestion;
 class MultiCursor;
 class Selection;
-class Suggestions;
 class Suggestion;
+class Suggestions;
 class TextIndex;
-class TextRangeCollectionIterator;
 class TextRangeCollection;
+class TextRangeCollectionIterator;
 
 template<size_t N>
 class TextRangeCombinerIterator;

--- a/libs/libedit/multicursor.cpp
+++ b/libs/libedit/multicursor.cpp
@@ -77,7 +77,7 @@ Cursor* MultiCursor::add_cursor_at(Document&, const TextIndex& index, const Text
 }
 
 void MultiCursor::install_document_listeners(Document& document) {
-    document.on<DeleteLines>(m_display.object(), [this, &document](const DeleteLines& event) {
+    document.on<DeleteLines>(m_display, [this, &document](const DeleteLines& event) {
         invalidate_cursor_history();
 
         for (auto& cursor : m_cursors) {
@@ -100,7 +100,7 @@ void MultiCursor::install_document_listeners(Document& document) {
         }
     });
 
-    document.on<AddLines>(m_display.object(), [this](const AddLines& event) {
+    document.on<AddLines>(m_display, [this](const AddLines& event) {
         invalidate_cursor_history();
 
         for (auto& cursor : m_cursors) {
@@ -114,7 +114,7 @@ void MultiCursor::install_document_listeners(Document& document) {
         }
     });
 
-    document.on<SplitLines>(m_display.object(), [this](const SplitLines& event) {
+    document.on<SplitLines>(m_display, [this](const SplitLines& event) {
         invalidate_cursor_history();
 
         for (auto& cursor : m_cursors) {
@@ -134,7 +134,7 @@ void MultiCursor::install_document_listeners(Document& document) {
         }
     });
 
-    document.on<MergeLines>(m_display.object(), [this](const MergeLines& event) {
+    document.on<MergeLines>(m_display, [this](const MergeLines& event) {
         invalidate_cursor_history();
 
         for (auto& cursor : m_cursors) {
@@ -153,7 +153,7 @@ void MultiCursor::install_document_listeners(Document& document) {
         }
     });
 
-    document.on<AddToLine>(m_display.object(), [this](const AddToLine& event) {
+    document.on<AddToLine>(m_display, [this](const AddToLine& event) {
         invalidate_cursor_history();
 
         for (auto& cursor : m_cursors) {
@@ -172,7 +172,7 @@ void MultiCursor::install_document_listeners(Document& document) {
         }
     });
 
-    document.on<DeleteFromLine>(m_display.object(), [this](const DeleteFromLine& event) {
+    document.on<DeleteFromLine>(m_display, [this](const DeleteFromLine& event) {
         invalidate_cursor_history();
 
         for (auto& cursor : m_cursors) {
@@ -191,7 +191,7 @@ void MultiCursor::install_document_listeners(Document& document) {
         }
     });
 
-    document.on<MoveLineTo>(m_display.object(), [this](const MoveLineTo& event) {
+    document.on<MoveLineTo>(m_display, [this](const MoveLineTo& event) {
         invalidate_cursor_history();
 
         auto line_min = min(event.line(), event.destination());

--- a/libs/libeventloop/CMakeLists.txt
+++ b/libs/libeventloop/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(SOURCES
-    component.cpp
     event_loop.cpp
     file_watcher.cpp
     input_tracker.cpp

--- a/libs/libeventloop/component.cpp
+++ b/libs/libeventloop/component.cpp
@@ -1,8 +1,0 @@
-#include <eventloop/component.h>
-#include <eventloop/object.h>
-
-namespace App {
-Component::Component(Object& object) : m_object(object) {
-    object.register_component(*this);
-}
-}

--- a/libs/libeventloop/include/eventloop/component.h
+++ b/libs/libeventloop/include/eventloop/component.h
@@ -1,27 +1,33 @@
 #pragma once
 
+#include <assert.h>
 #include <eventloop/forward.h>
 
 namespace App {
 class Component {
 public:
+    Component() {}
     virtual ~Component() {}
 
-    Object& object() const { return m_object; }
+    Object& object() const {
+        assert(m_object);
+        return *m_object;
+    }
 
     template<typename T>
     T& typed_object() const {
-        return static_cast<T&>(m_object);
+        return static_cast<T&>(object());
     }
 
-    void attach() { did_attach(); }
+    void attach(Object& object) {
+        m_object = &object;
+        did_attach();
+    }
 
 protected:
-    explicit Component(Object&);
-
     virtual void did_attach() {}
 
 private:
-    Object& m_object;
+    Object* m_object;
 };
 }

--- a/libs/libeventloop/include/eventloop/forward.h
+++ b/libs/libeventloop/include/eventloop/forward.h
@@ -2,9 +2,9 @@
 
 namespace App {
 class CallbackEvent;
-class Component;
 class Event;
 class EventLoop;
+class FdWrapper;
 class FileWatcher;
 class KeyBindings;
 class KeyEvent;

--- a/libs/libeventloop/include/eventloop/selectable.h
+++ b/libs/libeventloop/include/eventloop/selectable.h
@@ -21,6 +21,7 @@ class Selectable : public Object {
     APP_EMITS(Object, ReadableEvent, WritableEvent, ExceptionalEvent)
 
 public:
+    Selectable();
     virtual ~Selectable();
 
     void set_selected_events(int events) { m_selected_events = events; }

--- a/libs/libeventloop/include/eventloop/timer.h
+++ b/libs/libeventloop/include/eventloop/timer.h
@@ -15,8 +15,8 @@ class Timer : public Object {
     APP_EMITS(Object, TimerEvent)
 
 public:
-    static SharedPtr<Timer> create_interval_timer(SharedPtr<Object> parent, time_t ms);
-    static SharedPtr<Timer> create_single_shot_timer(SharedPtr<Object> parent, time_t ms);
+    static SharedPtr<Timer> create_interval_timer(Object* parent, time_t ms);
+    static SharedPtr<Timer> create_single_shot_timer(Object* parent, time_t ms);
 
     Timer();
     virtual void initialize() override;

--- a/libs/libeventloop/include/eventloop/unix_socket.h
+++ b/libs/libeventloop/include/eventloop/unix_socket.h
@@ -13,8 +13,8 @@ class UnixSocket final : public Selectable {
     APP_EMITS(Selectable, DisconnectEvent)
 
 public:
-    static SharedPtr<UnixSocket> create_from_fd(SharedPtr<Object> parent, int accepted_fd, bool nonblocking);
-    static SharedPtr<UnixSocket> create_connection(SharedPtr<Object> parent, const String& path);
+    static SharedPtr<UnixSocket> create_from_fd(Object* parent, int accepted_fd, bool nonblocking);
+    static SharedPtr<UnixSocket> create_connection(Object* parent, const String& path);
 
     ~UnixSocket();
 

--- a/libs/libeventloop/object.cpp
+++ b/libs/libeventloop/object.cpp
@@ -24,15 +24,7 @@ Object::~Object() {
     }
 }
 
-void Object::initialize() {
-    m_components.for_each_reverse([&](auto* component) {
-        component->attach();
-    });
-}
-
-void Object::register_component(Component& component) {
-    m_components.add(&component);
-}
+void Object::initialize() {}
 
 void Object::deferred_invoke(Function<void()> callback) {
     EventLoop::queue_event(weak_from_this(), make_unique<CallbackEvent>(move(callback)));

--- a/libs/libeventloop/selectable.cpp
+++ b/libs/libeventloop/selectable.cpp
@@ -3,6 +3,7 @@
 #include <eventloop/selectable.h>
 
 namespace App {
+Selectable::Selectable() {}
 
 Selectable::~Selectable() {
     disable_notifications();
@@ -26,5 +27,4 @@ void Selectable::disable_notifications() {
     EventLoop::unregister_selectable(*this);
     m_notifications_enabled = false;
 }
-
 }

--- a/libs/libeventloop/timer.cpp
+++ b/libs/libeventloop/timer.cpp
@@ -7,8 +7,8 @@
 
 namespace App {
 
-SharedPtr<Timer> Timer::create_interval_timer(SharedPtr<Object> parent, time_t ms) {
-    auto ret = Timer::create(move(parent));
+SharedPtr<Timer> Timer::create_interval_timer(Object* parent, time_t ms) {
+    auto ret = Timer::create(parent);
     if (!ret) {
         return ret;
     }
@@ -16,8 +16,8 @@ SharedPtr<Timer> Timer::create_interval_timer(SharedPtr<Object> parent, time_t m
     return ret;
 }
 
-SharedPtr<Timer> Timer::create_single_shot_timer(SharedPtr<Object> parent, time_t ms) {
-    auto ret = Timer::create(move(parent));
+SharedPtr<Timer> Timer::create_single_shot_timer(Object* parent, time_t ms) {
+    auto ret = Timer::create(parent);
     if (!ret) {
         return ret;
     }

--- a/libs/libeventloop/unix_socket.cpp
+++ b/libs/libeventloop/unix_socket.cpp
@@ -6,11 +6,11 @@
 #include <unistd.h>
 
 namespace App {
-SharedPtr<UnixSocket> UnixSocket::create_from_fd(SharedPtr<Object> parent, int fd, bool nonblocking) {
+SharedPtr<UnixSocket> UnixSocket::create_from_fd(Object* parent, int fd, bool nonblocking) {
     return UnixSocket::create(move(parent), fd, nonblocking);
 }
 
-SharedPtr<UnixSocket> UnixSocket::create_connection(SharedPtr<Object> parent, const String& path) {
+SharedPtr<UnixSocket> UnixSocket::create_connection(Object* parent, const String& path) {
     int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
     if (fd < 0) {
         return nullptr;

--- a/libs/libeventloop/unix_socket_server.cpp
+++ b/libs/libeventloop/unix_socket_server.cpp
@@ -16,7 +16,7 @@ UnixSocketServer::UnixSocketServer(const String& bind_path) {
     assert(bind_path.size() + 1 < sizeof(addr.sun_path));
     strcpy(addr.sun_path, bind_path.string());
     assert(bind(fd(), (const sockaddr*) &addr, sizeof(addr)) == 0);
-    assert(listen(fd(), 5) == 0);
+    assert(::listen(fd(), 5) == 0);
 
     set_selected_events(NotifyWhen::Readable);
     enable_notifications();
@@ -27,7 +27,7 @@ SharedPtr<UnixSocket> UnixSocketServer::accept() {
     if (fd < 0) {
         return nullptr;
     }
-    return UnixSocket::create_from_fd(shared_from_this(), fd, true);
+    return UnixSocket::create_from_fd(this, fd, true);
 }
 
 UnixSocketServer::~UnixSocketServer() {

--- a/libs/libipc/endpoint.cpp
+++ b/libs/libipc/endpoint.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 namespace IPC {
+Endpoint::Endpoint() {}
 
 Endpoint::~Endpoint() {}
 
@@ -81,5 +82,4 @@ void Endpoint::handle_messages() {
     }
     m_messages.clear();
 }
-
 }

--- a/libs/libipc/include/ipc/endpoint.h
+++ b/libs/libipc/include/ipc/endpoint.h
@@ -13,6 +13,7 @@ class Endpoint : public App::Object {
     APP_OBJECT(Endpoint)
 
 public:
+    Endpoint();
     virtual ~Endpoint() override;
 
     void set_dispatcher(SharedPtr<MessageDispatcher> dispatcher) { m_dispatcher = move(dispatcher); }

--- a/libs/libipc/server.cpp
+++ b/libs/libipc/server.cpp
@@ -9,12 +9,12 @@ Server::Server(String path, SharedPtr<MessageDispatcher> dispatcher) : m_path(mo
 
 void Server::initialize() {
     mode_t mode = umask(0002);
-    m_socket = App::UnixSocketServer::create(shared_from_this(), m_path);
+    m_socket = App::UnixSocketServer::create(this, m_path);
     umask(mode);
     m_socket->on<App::ReadableEvent>(*this, [this](auto&) {
         SharedPtr<App::UnixSocket> client_socket;
         while (client_socket = m_socket->accept()) {
-            auto client = Endpoint::create(shared_from_this());
+            auto client = Endpoint::create(this);
             client->set_socket(move(client_socket));
             client->set_dispatcher(m_dispatcher);
             client->on_disconnect = [this](auto& client) {

--- a/libs/librepl/repl_display.h
+++ b/libs/librepl/repl_display.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <edit/display.h>
+#include <edit/display_bridge.h>
 #include <eventloop/event.h>
 #include <liim/hash_map.h>
 #include <liim/maybe.h>
@@ -17,12 +18,14 @@ namespace Repl {
 
 class ReplDisplay final
     : public TUI::Panel
-    , public Edit::Display {
-    APP_OBJECT(ReplDisplay)
+    , public Edit::DisplayBridge {
+    APP_WIDGET_BASE(Edit::Display, TUI::Panel, ReplDisplay, self, self)
+
+    EDIT_DISPLAY_INTERFACE_FORWARD(base())
 
 public:
     explicit ReplDisplay(ReplBase& repl);
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~ReplDisplay() override;
 
     // ^TUI::Panel
@@ -42,6 +45,8 @@ public:
     virtual void send_status_message(String message) override;
     virtual void enter_search(String starting_text) override;
 
+    virtual Task<Maybe<String>> prompt(String message, String initial_value) override;
+    virtual App::ObjectBoundCoroutine do_open_prompt() override;
     virtual App::ObjectBoundCoroutine quit() override;
 
     virtual void set_clipboard_contents(String text, bool is_whole_line) override;

--- a/libs/librepl/suggestions_panel.cpp
+++ b/libs/librepl/suggestions_panel.cpp
@@ -1,3 +1,4 @@
+#include <app/base/widget.h>
 #include <edit/document.h>
 #include <eventloop/event.h>
 #include <tinput/terminal_glyph.h>
@@ -9,11 +10,11 @@
 namespace Repl {
 constexpr int max_visible_suggestions = 5;
 
-SuggestionsPanel::SuggestionsPanel(ReplDisplay& display) : m_display(display), m_suggestions(display.suggestions()) {
-    set_layout_constraint({ App::LayoutConstraint::AutoSize, max_visible_suggestions });
-}
+SuggestionsPanel::SuggestionsPanel(ReplDisplay& display) : m_display(display), m_suggestions(display.suggestions()) {}
 
-void SuggestionsPanel::initialize() {
+void SuggestionsPanel::did_attach() {
+    set_layout_constraint({ App::LayoutConstraint::AutoSize, max_visible_suggestions });
+
     on<App::KeyDownEvent>([this](const App::KeyDownEvent& event) {
         auto next_suggestion = [this] {
             if (m_suggestion_index < m_suggestions.size() - 1) {
@@ -59,7 +60,7 @@ void SuggestionsPanel::initialize() {
         return true;
     });
 
-    Panel::initialize();
+    Panel::did_attach();
 }
 
 SuggestionsPanel::~SuggestionsPanel() {}

--- a/libs/librepl/suggestions_panel.h
+++ b/libs/librepl/suggestions_panel.h
@@ -7,11 +7,11 @@ namespace Repl {
 class ReplDisplay;
 
 class SuggestionsPanel final : public TUI::Panel {
-    APP_OBJECT(SuggestionsPanel)
+    APP_WIDGET(TUI::Panel, SuggestionsPanel)
 
 public:
     explicit SuggestionsPanel(ReplDisplay& display);
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~SuggestionsPanel() override;
 
     virtual void render() override;

--- a/libs/librepl/terminal_input_source.cpp
+++ b/libs/librepl/terminal_input_source.cpp
@@ -14,7 +14,7 @@ public:
 
     virtual void do_add(App::Base::Widget& widget) override {
         assert(!m_display);
-        m_display = static_cast<ReplDisplay*>(&widget);
+        m_display = &widget;
     }
 
     virtual void do_remove(App::Base::Widget&) override {}
@@ -38,7 +38,7 @@ public:
     }
 
 private:
-    ReplDisplay* m_display { nullptr };
+    App::Base::Widget* m_display { nullptr };
     bool m_first_layout { true };
 };
 

--- a/libs/libtui/CMakeLists.txt
+++ b/libs/libtui/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     root_window.cpp
     table_view.cpp
     terminal_panel.cpp
+    view.cpp
 )
 
 add_os_library(libtui tui true)

--- a/libs/libtui/application.cpp
+++ b/libs/libtui/application.cpp
@@ -38,7 +38,7 @@ Application::Application(UniquePtr<TInput::IOTerminal> io_terminal) : m_io_termi
 }
 
 void Application::initialize() {
-    m_root_window = RootWindow::create(shared_from_this());
+    m_root_window = RootWindow::create(this);
     m_root_window->set_rect(m_io_terminal->terminal_rect());
 }
 

--- a/libs/libtui/frame.cpp
+++ b/libs/libtui/frame.cpp
@@ -1,7 +1,12 @@
+#include <app/base/widget.h>
 #include <tinput/terminal_renderer.h>
 #include <tui/frame.h>
 
 namespace TUI {
+Frame::Frame() {}
+
+Frame::~Frame() {}
+
 void Frame::render() {
     Panel::render();
 
@@ -19,6 +24,16 @@ Rect Frame::relative_inner_rect() const {
 
 Rect Frame::positioned_inner_rect() const {
     return positioned_rect().adjusted(-1);
+}
+
+void Frame::set_frame_color(Maybe<Color> c) {
+    m_frame_color = c;
+    invalidate();
+}
+
+void Frame::set_box_style(TInput::TerminalRenderer::BoxStyle box_style) {
+    m_box_style = box_style;
+    invalidate();
 }
 
 TInput::TerminalRenderer Frame::get_renderer_inside_frame() {

--- a/libs/libtui/include/tui/frame.h
+++ b/libs/libtui/include/tui/frame.h
@@ -4,24 +4,21 @@
 #include <tui/panel.h>
 
 namespace TUI {
-class Frame : public TUI::Panel {
-    APP_OBJECT(Frame)
+class Frame : public Panel {
+    APP_WIDGET(Panel, Frame)
 
 public:
+    Frame();
+    virtual ~Frame() override;
+
     virtual void render() override;
 
     Rect positioned_inner_rect() const;
     Rect relative_inner_rect() const;
     Rect sized_inner_rect() const;
 
-    void set_frame_color(Maybe<Color> c) {
-        m_frame_color = c;
-        invalidate();
-    }
-    void set_box_style(TInput::TerminalRenderer::BoxStyle box_style) {
-        m_box_style = box_style;
-        invalidate();
-    }
+    void set_frame_color(Maybe<Color> c);
+    void set_box_style(TInput::TerminalRenderer::BoxStyle box_style);
 
 protected:
     TInput::TerminalRenderer get_renderer_inside_frame();

--- a/libs/libtui/include/tui/label.h
+++ b/libs/libtui/include/tui/label.h
@@ -7,7 +7,7 @@
 
 namespace TUI {
 class Label : public Panel {
-    APP_OBJECT(Label)
+    APP_WIDGET(Panel, Label)
 
 public:
     explicit Label(String text) : m_text(move(text)) {}

--- a/libs/libtui/include/tui/panel.h
+++ b/libs/libtui/include/tui/panel.h
@@ -1,26 +1,31 @@
 #pragma once
 
 #include <app/base/widget.h>
+#include <app/base/widget_bridge.h>
+#include <app/forward.h>
+#include <eventloop/component.h>
+#include <eventloop/forward.h>
 #include <graphics/rect.h>
 #include <liim/forward.h>
 #include <tinput/forward.h>
 #include <tui/forward.h>
 
 namespace TUI {
-class Panel : public App::Base::Widget {
-    APP_OBJECT(Panel)
+class Panel
+    : public App::Component
+    , public App::Base::WidgetBridge {
+    APP_WIDGET_BASE(App::Base::Widget, App::Base::WidgetBridge, Panel, self)
+
+    APP_OBJECT_FORWARD_API(base())
+
+    APP_BASE_WIDGET_INTERFACE_FORWARD(base())
 
 public:
     Panel();
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~Panel() override;
-
-    Panel* parent_panel();
 
 protected:
     TInput::TerminalRenderer get_renderer();
-
-private:
-    virtual bool is_panel() const final { return true; }
 };
 }

--- a/libs/libtui/include/tui/root_window.h
+++ b/libs/libtui/include/tui/root_window.h
@@ -7,6 +7,7 @@ class RootWindow final : public App::Base::Window {
     APP_OBJECT(RootWindow)
 
 public:
+    RootWindow() {}
     virtual void initialize() override;
 
 protected:

--- a/libs/libtui/include/tui/table_view.h
+++ b/libs/libtui/include/tui/table_view.h
@@ -4,9 +4,11 @@
 
 namespace TUI {
 class TableView : public View {
-    APP_OBJECT(TableView)
+    APP_WIDGET(View, TableView)
 
 public:
+    TableView() {}
+
     virtual void render() override;
     virtual App::ModelItem* item_at_position(const Point&) override { return nullptr; }
 };

--- a/libs/libtui/include/tui/terminal_panel.h
+++ b/libs/libtui/include/tui/terminal_panel.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <app/base/terminal_widget.h>
+#include <app/base/terminal_widget_bridge.h>
 #include <tui/panel.h>
 
 namespace TUI {
 class TerminalPanel
     : public TUI::Panel
-    , public App::Base::TerminalWidget {
-    APP_OBJECT(TerminalPanel)
+    , public App::Base::TerminalWidgetBridge {
+    APP_WIDGET_BASE(App::Base::TerminalWidget, TUI::Panel, TerminalPanel, self, self)
 
-    APP_EMITS(TUI::Panel, App::TerminalHangupEvent)
+    APP_BASE_TERMINAL_WIDGET_INTERFACE_FORWARD(base())
 
 public:
     TerminalPanel();
@@ -18,9 +19,9 @@ public:
     virtual Maybe<Point> cursor_position() override;
     virtual void render() override;
 
-    // ^App::Base::BaseTerminalWidget
-    virtual void invalidate_all_contents() override { invalidate(); }
-    virtual Rect available_cells() const override { return sized_rect(); }
-    virtual Point cell_position_of_mouse_coordinates(int mouse_x, int mouse_y) const override { return { mouse_x, mouse_y }; }
+    // ^App::Base::TerminalWidgetBridge
+    virtual void invalidate_all_contents() override;
+    virtual Rect available_cells() const override;
+    virtual Point cell_position_of_mouse_coordinates(int mouse_x, int mouse_y) const override;
 };
 }

--- a/libs/libtui/include/tui/view.h
+++ b/libs/libtui/include/tui/view.h
@@ -1,21 +1,22 @@
 #pragma once
 
 #include <app/base/view.h>
+#include <app/base/view_bridge.h>
 #include <tui/panel.h>
 
 namespace TUI {
 class View
     : public Panel
-    , public App::Base::View {
-    APP_OBJECT(View)
+    , public App::Base::ViewBridge {
+    APP_WIDGET_BASE(App::Base::View, Panel, View, self, self, nullptr)
 
-    APP_EMITS(Panel, App::ViewRootChanged, App::ViewItemActivated)
+    APP_BASE_VIEW_INTERFACE_FORWARD(base())
 
 protected:
-    View() : App::Base::View(static_cast<Object&>(*this)) {}
+    View() {}
 
 private:
     // ^Base::View
-    virtual void invalidate_all() override { invalidate(); }
+    virtual void invalidate_all() override;
 };
 }

--- a/libs/libtui/label.cpp
+++ b/libs/libtui/label.cpp
@@ -1,3 +1,4 @@
+#include <app/base/widget.h>
 #include <tinput/terminal_glyph.h>
 #include <tinput/terminal_renderer.h>
 #include <tui/label.h>

--- a/libs/libtui/panel.cpp
+++ b/libs/libtui/panel.cpp
@@ -1,3 +1,4 @@
+#include <app/base/widget.h>
 #include <eventloop/event.h>
 #include <eventloop/key_bindings.h>
 #include <liim/maybe.h>
@@ -8,7 +9,7 @@
 namespace TUI {
 Panel::Panel() {}
 
-void Panel::initialize() {
+void Panel::did_attach() {
     on<App::FocusedEvent>([this](auto&) {
         if (cursor_position().has_value()) {
             if (auto* window = parent_window()) {
@@ -16,15 +17,9 @@ void Panel::initialize() {
             }
         }
     });
-
-    App::Base::Widget::initialize();
 }
 
 Panel::~Panel() {}
-
-Panel* Panel::parent_panel() {
-    return static_cast<Panel*>(parent_widget());
-}
 
 TInput::TerminalRenderer Panel::get_renderer() {
     auto dirty_rects = TUI::Application::the().root_window().dirty_rects();
@@ -37,7 +32,7 @@ TInput::TerminalRenderer Panel::get_renderer() {
             }
         }
     };
-    enumerate_children(*this);
+    enumerate_children(base());
 
     auto renderer = TInput::TerminalRenderer { Application::the().io_terminal(), dirty_rects };
     renderer.set_clip_rect(positioned_rect());

--- a/libs/libtui/root_window.cpp
+++ b/libs/libtui/root_window.cpp
@@ -18,7 +18,7 @@ void RootWindow::initialize() {
 void RootWindow::do_render() {
     auto& io_terminal = TUI::Application::the().io_terminal();
     io_terminal.set_show_cursor(false);
-    main_widget().render();
+    main_widget().render_including_children();
 
     if (auto panel = focused_widget()) {
         if (auto cursor_position = panel->cursor_position()) {

--- a/libs/libtui/table_view.cpp
+++ b/libs/libtui/table_view.cpp
@@ -1,3 +1,4 @@
+#include <app/base/view.h>
 #include <app/model.h>
 #include <app/model_item_info.h>
 #include <tinput/terminal_renderer.h>
@@ -11,7 +12,7 @@ void TableView::render() {
         return;
     }
 
-    auto* root_item = model()->model_item_root();
+    auto* root_item = this->root_item();
     auto item_count = root_item->item_count();
     for (int i = 0; i < item_count; i++) {
         auto info = root_item->model_item_at(i)->info(0, App::ModelItemInfo::Request::Text);

--- a/libs/libtui/terminal_panel.cpp
+++ b/libs/libtui/terminal_panel.cpp
@@ -3,9 +3,7 @@
 #include <tui/terminal_panel.h>
 
 namespace TUI {
-TerminalPanel::TerminalPanel() : TerminalWidget(static_cast<Object&>(*this)) {
-    set_accepts_focus(true);
-}
+TerminalPanel::TerminalPanel() {}
 
 Maybe<Point> TerminalPanel::cursor_position() {
     if (tty().cursor_hidden()) {
@@ -47,5 +45,17 @@ void TerminalPanel::render() {
                                  { .foreground = fg, .background = bg, .bold = cell.bold, .invert = cell.inverted });
         }
     }
+}
+
+void TerminalPanel::invalidate_all_contents() {
+    invalidate();
+}
+
+Rect TerminalPanel::available_cells() const {
+    return sized_rect();
+}
+
+Point TerminalPanel::cell_position_of_mouse_coordinates(int mouse_x, int mouse_y) const {
+    return { mouse_x, mouse_y };
 }
 }

--- a/libs/libtui/view.cpp
+++ b/libs/libtui/view.cpp
@@ -1,0 +1,8 @@
+#include <app/base/view.h>
+#include <tui/view.h>
+
+namespace TUI {
+void View::invalidate_all() {
+    invalidate();
+}
+}

--- a/userland/about/main.cpp
+++ b/userland/about/main.cpp
@@ -13,16 +13,18 @@
 #include <unistd.h>
 
 class TestWidget : public App::Widget {
-    APP_OBJECT(TestWidget)
+    APP_WIDGET(App::Widget, TestWidget)
 
-private:
-    virtual void initialize() override {
+public:
+    TestWidget() {}
+
+    virtual void did_attach() override {
         on<App::TextEvent>([](const App::TextEvent& event) {
             out_log("typed: '{}'", event.text());
             return true;
         });
 
-        Widget::initialize();
+        Widget::did_attach();
     }
 };
 
@@ -58,7 +60,7 @@ int main() {
         printf("clicked!\n");
     });
 
-    auto context_menu = App::ContextMenu::create(window, window);
+    auto context_menu = App::ContextMenu::create(window.get(), window);
     context_menu->add_menu_item("A", [] {
         printf("A Pressed\n");
     });

--- a/userland/clipboard_server/main.cpp
+++ b/userland/clipboard_server/main.cpp
@@ -18,8 +18,10 @@ class Dispatcher final : public Client::MessageDispatcher {
     APP_OBJECT(Dispatcher)
 
 public:
+    Dispatcher() {}
+
     virtual void initialize() override {
-        m_server = IPC::Server::create(shared_from_this(), "/tmp/.clipboard_server.socket", shared_from_this());
+        m_server = IPC::Server::create(this, "/tmp/.clipboard_server.socket", shared_from_this());
 
         Client::MessageDispatcher::initialize();
     }

--- a/userland/edit/app_display.h
+++ b/userland/edit/app_display.h
@@ -2,6 +2,7 @@
 
 #include <app/widget.h>
 #include <edit/display.h>
+#include <edit/display_bridge.h>
 #include <graphics/forward.h>
 #include <liim/function.h>
 #include <liim/string.h>
@@ -10,7 +11,7 @@
 class AppDisplay;
 
 class SearchWidget final : public App::Widget {
-    APP_OBJECT(SearchWidget)
+    APP_WIDGET(App::Widget, SearchWidget)
 
 public:
     SearchWidget();
@@ -26,11 +27,14 @@ private:
 
 class AppDisplay final
     : public App::Widget
-    , public Edit::Display {
-    APP_OBJECT(AppDisplay)
+    , public Edit::DisplayBridge {
+    APP_WIDGET_BASE(Edit::Display, App::Widget, AppDisplay, self, self)
+
+    EDIT_DISPLAY_INTERFACE_FORWARD(base())
 
 public:
-    virtual void initialize() override;
+    explicit AppDisplay(bool m_main_display = true);
+    virtual void did_attach() override;
     virtual ~AppDisplay() override;
 
     virtual int rows() const override { return m_rows; }
@@ -48,9 +52,11 @@ public:
     }
     virtual int enter() override;
     virtual void send_status_message(String message) override;
+    virtual Task<Maybe<String>> prompt(String message, String initial_value) override;
     virtual void enter_search(String starting_text) override;
 
     virtual App::ObjectBoundCoroutine quit() override;
+    virtual App::ObjectBoundCoroutine do_open_prompt() override;
 
     virtual void set_clipboard_contents(String text, bool is_whole_line) override;
     virtual String clipboard_contents(bool& is_whole_line) const override;
@@ -65,8 +71,6 @@ private:
         bool dirty;
         Edit::CharacterMetadata metadata;
     };
-
-    explicit AppDisplay(bool m_main_display = true);
 
     AppDisplay& ensure_search_display();
 

--- a/userland/edit/main.cpp
+++ b/userland/edit/main.cpp
@@ -15,9 +15,11 @@
 #include "terminal_status_bar.h"
 
 class BackgroundPanel : public TUI::Panel {
-    APP_OBJECT(BackgroundPanel)
+    APP_WIDGET(TUI::Panel, BackgroundPanel)
 
 public:
+    BackgroundPanel() {}
+
     virtual void render() override {
         auto renderer = get_renderer();
 
@@ -135,7 +137,7 @@ int main(int argc, char** argv) {
         key_bindings.add({ App::Key::LeftArrow, App::KeyModifier::Control, App::KeyShortcut::IsMulti::Yes }, [&display_conainer, &display] {
             auto prev_child = static_cast<const App::Object*>(nullptr);
             for (auto& child : display_conainer.children()) {
-                if (child.get() == &display) {
+                if (child.get() == &display.base()) {
                     break;
                 }
                 prev_child = child.get();
@@ -150,7 +152,7 @@ int main(int argc, char** argv) {
                              auto prev_child = static_cast<const App::Object*>(nullptr);
                              for (int i = display_conainer.children().size() - 1; i >= 0; i--) {
                                  auto& child = display_conainer.children()[i];
-                                 if (child.get() == &display) {
+                                 if (child.get() == &display.base()) {
                                      break;
                                  }
                                  prev_child = child.get();
@@ -212,7 +214,7 @@ int main(int argc, char** argv) {
         }
 
         terminal_container.set_hidden(false);
-        terminal = terminal_container_layout.add<TUI::TerminalPanel>().shared_from_this();
+        terminal = terminal_container_layout.add_owned<TUI::TerminalPanel>();
         terminal->on<App::TerminalHangupEvent>({}, [&terminal, &terminal_container, &display_conainer](auto&) {
             terminal_container.set_hidden(true);
             terminal->remove();

--- a/userland/edit/terminal_display.h
+++ b/userland/edit/terminal_display.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <edit/display.h>
+#include <edit/display_bridge.h>
 #include <eventloop/event.h>
 #include <liim/hash_map.h>
 #include <liim/maybe.h>
@@ -15,14 +16,14 @@ class TerminalSearch;
 
 class TerminalDisplay final
     : public TUI::Panel
-    , public Edit::Display {
-    APP_OBJECT(TerminalDisplay)
+    , public Edit::DisplayBridge {
+    APP_WIDGET_BASE(Edit::Display, TUI::Panel, TerminalDisplay, self, self)
 
-    APP_EMITS(TUI::Panel, Edit::SplitDisplayEvent, Edit::NewDisplayEvent)
+    EDIT_DISPLAY_INTERFACE_FORWARD(base())
 
 public:
     TerminalDisplay();
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~TerminalDisplay() override;
 
     // ^TUI::Panel
@@ -30,7 +31,7 @@ public:
     virtual void render() override;
     virtual Maybe<Point> cursor_position() override;
 
-    // ^Edit::Display
+    // ^Edit::DisplayBridge
     virtual int rows() const override { return sized_rect().height(); }
     virtual int cols() const override;
 

--- a/userland/edit/terminal_prompt.h
+++ b/userland/edit/terminal_prompt.h
@@ -9,16 +9,14 @@ class TerminalDisplay;
 APP_EVENT(Edit, PromptResult, App::Event, (), ((Maybe<String>, result)), ())
 
 class TerminalPrompt final : public TUI::Frame {
-    APP_OBJECT(TerminalPrompt)
-
-    APP_EMITS(TUI::Frame, Edit::PromptResult)
+    APP_WIDGET_EMITS(TUI::Frame, TerminalPrompt, (Edit::PromptResult))
 
 public:
     TerminalPrompt(TerminalDisplay& host_display, String prompt, String initial_value);
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~TerminalPrompt() override;
 
-    Task<Maybe<String>> block_until_result(Object& coroutine_owner);
+    Task<Maybe<String>> block_until_result(App::Object& coroutine_owner);
 
 private:
     TerminalDisplay& m_host_display;

--- a/userland/edit/terminal_search.h
+++ b/userland/edit/terminal_search.h
@@ -6,11 +6,11 @@
 class TerminalDisplay;
 
 class TerminalSearch final : public TUI::Frame {
-    APP_OBJECT(TerminalSearch)
+    APP_WIDGET(TUI::Frame, TerminalSearch)
 
 public:
-    TerminalSearch(TerminalDisplay& hots_display, String initial_text);
-    virtual void initialize() override;
+    TerminalSearch(TerminalDisplay& host_display, String initial_text);
+    virtual void did_attach() override;
     virtual ~TerminalSearch() override;
 
 private:

--- a/userland/edit/terminal_status_bar.cpp
+++ b/userland/edit/terminal_status_bar.cpp
@@ -14,17 +14,19 @@ TerminalStatusBar& TerminalStatusBar::the() {
 
 TerminalStatusBar::TerminalStatusBar() {
     s_the = this;
+}
 
+void TerminalStatusBar::did_attach() {
     set_layout_constraint({ App::LayoutConstraint::AutoSize, 1 });
 }
 
 TerminalStatusBar::~TerminalStatusBar() {}
 
-void TerminalStatusBar::display_did_update(TerminalDisplay&) {
+void TerminalStatusBar::display_did_update(Edit::Display&) {
     invalidate();
 }
 
-void TerminalStatusBar::set_active_display(TerminalDisplay* display) {
+void TerminalStatusBar::set_active_display(Edit::Display* display) {
     if (!display) {
         m_active_display.reset();
         invalidate();
@@ -37,8 +39,8 @@ void TerminalStatusBar::set_active_display(TerminalDisplay* display) {
 
 void TerminalStatusBar::set_status_message(String message) {
     m_status_message = move(message);
-    m_status_message_timer = App::Timer::create_single_shot_timer(shared_from_this(), 3000);
-    m_status_message_timer->on<App::TimerEvent>(*this, [this](auto&) {
+    m_status_message_timer = App::Timer::create_single_shot_timer(&base(), 3000);
+    listen<App::TimerEvent>(*m_status_message_timer, [this](auto&) {
         m_status_message = {};
         invalidate();
     });

--- a/userland/edit/terminal_status_bar.h
+++ b/userland/edit/terminal_status_bar.h
@@ -3,27 +3,26 @@
 #include <eventloop/timer.h>
 #include <tui/panel.h>
 
-class TerminalDisplay;
-
 class TerminalStatusBar final : public TUI::Panel {
-    APP_OBJECT(TerminalStatusBar)
+    APP_WIDGET(TUI::Panel, TerminalStatusBar)
 
 public:
     static TerminalStatusBar& the();
 
     TerminalStatusBar();
+    virtual void did_attach() override;
     virtual ~TerminalStatusBar() override;
 
-    void set_active_display(TerminalDisplay* display);
+    void set_active_display(Edit::Display* display);
     void set_status_message(String message);
-    void display_did_update(TerminalDisplay& display);
+    void display_did_update(Edit::Display& display);
 
     virtual void render() override;
 
-    TerminalDisplay& active_display() { return *m_active_display.lock(); }
+    Edit::Display& active_display() { return *m_active_display.lock(); }
 
 private:
-    WeakPtr<TerminalDisplay> m_active_display;
+    WeakPtr<Edit::Display> m_active_display;
     Maybe<String> m_status_message;
     SharedPtr<App::Timer> m_status_message_timer;
 };

--- a/userland/psfedit/main.cpp
+++ b/userland/psfedit/main.cpp
@@ -12,10 +12,12 @@
 #include <unistd.h>
 
 class GlyphEditorWidgetCell final : public App::Widget {
-    APP_OBJECT(GlyphEditorWidgetCell)
+    APP_WIDGET(App::Widget, GlyphEditorWidgetCell)
 
 public:
-    virtual void initialize() override {
+    GlyphEditorWidgetCell(Bitset<uint8_t>*& bitset, int index) : m_bitset(bitset), m_index(index) {}
+
+    virtual void did_attach() override {
         on<App::MouseDownEvent>([this](const App::MouseDownEvent& event) {
             if (m_bitset && event.left_button()) {
                 m_bitset->flip(m_index);
@@ -25,7 +27,7 @@ public:
             return false;
         });
 
-        App::Widget::initialize();
+        App::Widget::did_attach();
     }
 
     virtual void render() {
@@ -40,26 +42,23 @@ public:
         renderer.draw_rect(sized_rect(), ColorValue::Black);
     }
 
-private:
-    GlyphEditorWidgetCell(Bitset<uint8_t>*& bitset, int index) : m_bitset(bitset), m_index(index) {}
-
     Bitset<uint8_t>*& m_bitset;
     int m_index { 0 };
 };
 
 class GlyphEditorWidget final : public App::Widget {
-    APP_OBJECT(GlyphEditorWidget)
+    APP_WIDGET(App::Widget, GlyphEditorWidget)
 
 public:
+    GlyphEditorWidget(int width, int height, SharedPtr<Font> font) : m_width(width), m_height(height) { set_font(font); }
+
     void set_bitset(Bitset<uint8_t>* bitset, char c) {
         m_bitset = bitset;
         m_info_label->set_text(String::format("Editing glyph %d (%c)", c, c));
         invalidate();
     }
 
-private:
-    GlyphEditorWidget(int width, int height, SharedPtr<Font> font) : m_width(width), m_height(height) { set_font(font); }
-    virtual void initialize() override {
+    virtual void did_attach() override {
         auto& layout = set_layout_engine<App::HorizontalFlexLayoutEngine>();
         auto& left_container = layout.add<App::Widget>();
 
@@ -77,7 +76,7 @@ private:
         auto& text_container = layout.add<App::Widget>();
         auto& text_layout = text_container.set_layout_engine<App::VerticalFlexLayoutEngine>();
 
-        m_info_label = text_layout.add<App::TextLabel>("").shared_from_this();
+        m_info_label = text_layout.add_owned<App::TextLabel>("");
 
         auto& demo_label = text_layout.add<App::TextLabel>("abcdefghijklmnopqrstuvwxyz\n"
                                                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ\n"
@@ -85,7 +84,7 @@ private:
                                                            "[]{}\\|;:'\",.<>/?");
         demo_label.set_font(font());
 
-        App::Widget::initialize();
+        App::Widget::did_attach();
     }
 
     Bitset<uint8_t>* m_bitset { nullptr };

--- a/userland/system_monitor/process_tab.cpp
+++ b/userland/system_monitor/process_tab.cpp
@@ -6,14 +6,14 @@
 
 ProcessTab::ProcessTab(SharedPtr<ProcessModel> model) : m_model(move(model)) {}
 
-void ProcessTab::initialize() {
+void ProcessTab::did_attach() {
     auto& layout = set_layout_engine<App::VerticalFlexLayoutEngine>();
     layout.set_margins({ 0, 0, 0, 0 });
 
     auto& tabel = layout.add<App::TableView>();
     tabel.set_model(m_model);
 
-    Widget::initialize();
+    Widget::did_attach();
 }
 
 ProcessTab::~ProcessTab() {}

--- a/userland/system_monitor/process_tab.h
+++ b/userland/system_monitor/process_tab.h
@@ -5,11 +5,11 @@
 class ProcessModel;
 
 class ProcessTab final : public App::Widget {
-    APP_OBJECT(ProcessTab)
+    APP_WIDGET(App::Widget, ProcessTab)
 
 public:
     ProcessTab(SharedPtr<ProcessModel> model);
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~ProcessTab() override;
 
 private:

--- a/userland/system_monitor/resource_usage_tab.cpp
+++ b/userland/system_monitor/resource_usage_tab.cpp
@@ -6,19 +6,19 @@
 
 ResourceUsageTab::ResourceUsageTab(SharedPtr<ProcessModel> model) : m_model(move(model)) {}
 
-void ResourceUsageTab::initialize() {
+void ResourceUsageTab::did_attach() {
     auto& layout = set_layout_engine<App::VerticalFlexLayoutEngine>();
     layout.set_margins({ 0, 0, 0, 0 });
     layout.set_spacing(0);
-    m_cpu_label = layout.add<App::TextLabel>("CPU: 0%").shared_from_this();
-    m_memory_label = layout.add<App::TextLabel>("Memory: 0 / 0 (0%)").shared_from_this();
+    m_cpu_label = layout.add_owned<App::TextLabel>("CPU: 0%");
+    m_memory_label = layout.add_owned<App::TextLabel>("Memory: 0 / 0 (0%)");
 
-    m_model->on<App::ModelUpdateEvent>(*this, [this](auto&) {
+    listen<App::ModelUpdateEvent>(*m_model, [this](auto&) {
         update_display();
     });
     update_display();
 
-    Widget::initialize();
+    Widget::did_attach();
 }
 
 ResourceUsageTab::~ResourceUsageTab() {}

--- a/userland/system_monitor/resource_usage_tab.h
+++ b/userland/system_monitor/resource_usage_tab.h
@@ -5,11 +5,11 @@
 class ProcessModel;
 
 class ResourceUsageTab final : public App::Widget {
-    APP_OBJECT(ResourceUsageTab)
+    APP_WIDGET(App::Widget, ResourceUsageTab)
 
 public:
     explicit ResourceUsageTab(SharedPtr<ProcessModel> model);
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~ResourceUsageTab() override;
 
     void update_display();

--- a/userland/taskbar/taskbar.cpp
+++ b/userland/taskbar/taskbar.cpp
@@ -10,9 +10,9 @@
 namespace Taskbar {
 Taskbar::Taskbar() {}
 
-void Taskbar::initialize() {
-    m_time_timer = App::Timer::create_interval_timer(shared_from_this(), 1000);
-    m_time_timer->on<App::TimerEvent>(*this, [this](auto&) {
+void Taskbar::did_attach() {
+    m_time_timer = App::Timer::create_interval_timer(&base(), 1000);
+    listen<App::TimerEvent>(*m_time_timer, [this](auto&) {
         invalidate();
     });
 
@@ -39,7 +39,7 @@ void Taskbar::initialize() {
         return false;
     });
 
-    Widget::initialize();
+    Widget::did_attach();
 }
 
 Taskbar::~Taskbar() {}

--- a/userland/taskbar/taskbar.h
+++ b/userland/taskbar/taskbar.h
@@ -18,11 +18,11 @@ constexpr int taskbar_button_y_margin = 8;
 class Taskbar final
     : public App::Widget
     , public App::WindowServerListener {
-    APP_OBJECT(Taskbar)
+    APP_WIDGET(App::Widget, Taskbar)
 
 public:
     Taskbar();
-    virtual void initialize() override;
+    virtual void did_attach() override;
     virtual ~Taskbar() override;
 
     virtual void render() override;

--- a/userland/window_server/server.cpp
+++ b/userland/window_server/server.cpp
@@ -53,7 +53,7 @@ ServerImpl::ServerImpl(int fb, SharedPtr<Bitmap> front_buffer, SharedPtr<Bitmap>
 }
 
 void ServerImpl::initialize() {
-    m_input_socket = App::FdWrapper::create(shared_from_this(), socket(AF_UMESSAGE, SOCK_DGRAM | SOCK_NONBLOCK, UMESSAGE_INPUT));
+    m_input_socket = App::FdWrapper::create(this, socket(AF_UMESSAGE, SOCK_DGRAM | SOCK_NONBLOCK, UMESSAGE_INPUT));
     assert(m_input_socket->valid());
     m_input_socket->set_selected_events(App::NotifyWhen::Readable);
     m_input_socket->enable_notifications();
@@ -112,9 +112,9 @@ void ServerImpl::initialize() {
         }
     });
 
-    m_server = IPC::Server::create(shared_from_this(), "/tmp/.window_server.socket", shared_from_this());
+    m_server = IPC::Server::create(this, "/tmp/.window_server.socket", shared_from_this());
 
-    m_draw_timer = App::Timer::create_single_shot_timer(shared_from_this(), draw_timer_rate);
+    m_draw_timer = App::Timer::create_single_shot_timer(this, draw_timer_rate);
     m_draw_timer->on<App::TimerEvent>(*this, [this](auto&) {
         m_manager->draw();
     });


### PR DESCRIPTION
# Problem

The current architecture of libapp (GUI library) is fundamentally flawed because it requires multiple (C++ virtual) inheritance. This is caused by having abstract base classes (in the App::Base namespace) being shared between 2 different rendering frontends (2d pixel graphics and terminal). Each descendant in the App::Base namespace requires more methods to be implemented by a client in order to function properly. For instance, App::Base::Widget just needs a render method, while App::Base::View needs to be able to lookup a App::ModelItem from a position the user clicked on. However, any class using the 2d graphics frontend can share the same implementation of the App::Base::Widget contract, but accomplishing this becomes impossible without multiple inheritance. The current solution is to prevent anything in App::Base from inheriting classes, but this is a temporary solution which even breaks down when adding plugin like behaviors (like App::Base::ScrollComponent).

# Original Class Diagram

```
App::Object -> App::Base::Widget -> App::Widget -> App::View -----------> App::TableView
          |                                         ^                           ^
          |----> App::Base::View -------------------|-> App::Base::TableView  --|
```

This reveals a parallel class hierarchy where each class in App::Base wants to have a corresponding class in the App namespace, which wants to inherit from 2 classes. This creates the massive problem which leads to this redesign of the entire library.

# Solution

The proposal is akin to the [bridge design pattern](https://refactoring.guru/design-patterns/bridge) (described in Refactoring GURU). However, each new level of inheritance needs to define a new bridge class. The class diagram should instead now look like a ladder.

```
App::Object
     ↓
App::Base::Widget     -> App::Base::Widget::Bridge      -> App::Widget
     ↓                                                          ↓
App::Base::View       -> App::Base::View::Bridge        -> App::View
     ↓                                                          ↓
App::Base::TableView  -> App::Base::TableView::Bridge   -> App::TableView
```

A key point to this diagram is that the bridges inherit from no one, but classes like App::View will inherit from both App::Widget and the base view's bridge. In this architecture, App::Base::View stores a App::Base::View::Bridge internally which is initialized in its constructor. Since App::View also needs a pointer to its containing App::Base::View, App::View will provide a dedicated factory function which creates an App::Base::View with its bridge initialized properly.

# Adding more components

Some additional GUI functionality, like scrolling, can be modelled as a plugin to an existing App::Base::Widget. However, scrolling too has a logical component which is separated from the underlying platform (2d graphics vs. terminal). This can be accomplished by adding a bridge between the App::Base::ScrollComponent and the 2d graphics aware App::ScrollComponent. App::Base classes which need to scroll work by owning a App::Base::ScrollComponent but taking a bridge implementation in its constructor. App::Widget subclasses can inherit from App::ScrollComponent directly, and use itself to satify the bridge requirement.

```
App::Base::View   <-   App::Base::ScrollComponent
     ↓                          ↓
App::View           App::Base::ScrollComponent::Bridge
     ↑                          ↓
     ↑          <-     App::ScrollComponent
```

# New API

Now that App::Widget does not derive from App::Base::Widget, custom widgets will also not have direct access to a Base::Widget. This is problematic because most code wants to work with Base::Widget directly (for doing layout, or getting the current widget rect, etc...), which makes custom widgets' code more verbose. This is solved using 2 new ideas. The first is that every custom/platform specific widget must include some form of the APP_WIDGET() macro. This establishes important things like widget construction, what type of events can be emiited, and sets up the basis for forwarding calls to the base widget. The second new component is the newly added gen/reflect module. This code aims to "parse" a c++ header file and generate code which allows another class to have direct access to some of its member functions. This allows custom widgets to call functions like `sized_rect()` or `set_layout_engine()` directly, without having to explicitly go through base. This reflection mechanism works simply by only reading the parts of the class definition between comments of the form `// os_2 reflect {begin|end}`. This forwarding mechanism can additionally be used by base classes to gain direct access to methods defined in their bridge class. This greatly reduces the amount of boilerplate code in this new design.

A danger with this new API is that the base object and the custom widget are not created at the same time. This means that any constructor of a custom widget cannot attempt to call through to a Base::Widget method. If it does, the base() method will assert. Before adding this assertion, code directly would directly crash. This was the single most common error encountered during this refactoring.
