### PR TITLE
meta: fixup some doc issues

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Deploy and Generate Documentation
 on:
   push:
     branches: [iris]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -43,3 +44,4 @@ jobs:
           commit-message: 'docs: deploy documentation site'
           single-commit: true
           branch: gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/head/iris'

--- a/meta/cmake/doxygen.cmake
+++ b/meta/cmake/doxygen.cmake
@@ -28,6 +28,7 @@ include(ExternalProject)
     set(DOXYGEN_INCLUDED_BY_GRAPH NO)
     set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${CMAKE_CURRENT_SOURCE_DIR}/docs/mainpage.md")
     set(DOXYGEN_LAYOUT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/docs/DoxygenLayout.xml")
+    set(DOXYGEN_IMAGE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagram")
     set(DOXYGEN_EXCLUDE_PATTERNS "*/tests/*")
     set(DOXYGEN_PREDEFINED
         __CCPP_BEGIN_DECLARATIONS=
@@ -54,10 +55,5 @@ include(ExternalProject)
         ${CMAKE_CURRENT_SOURCE_DIR}/docs
     )
 
-    add_custom_target(docs_diagram_install
-        COMMAND "${CMAKE_COMMAND}" -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/docs/diagram" "${CMAKE_BINARY_DIR}/html/docs/diagram"
-    )
-
     add_dependencies(docs doxygen_awesome_css)
-    add_dependencies(docs docs_diagram_install)
 endif()

--- a/meta/make-iris-limine-image.sh
+++ b/meta/make-iris-limine-image.sh
@@ -58,6 +58,8 @@ fi
 
 LOOP_DEV=$(losetup --partscan -f "$IMAGE" --show)
 
+partprobe
+
 # HACK to make partitions show up in a docker container
 # https://github.com/moby/moby/issues/27886#issuecomment-417074845
 # drop the first line, as this is our LOOP_DEV itself, but we only want the child partitions


### PR DESCRIPTION
The first is to ensure the docs build in CI before merging. The second is to configure the doxygen image path so that it finds images in the markdown documentation files.