### PR TITLE
dius: improve test framework support on Iros

### DIFF
--- a/libs/dius/CMakeLists.txt
+++ b/libs/dius/CMakeLists.txt
@@ -29,6 +29,7 @@ if(LINUX)
       PRIVATE
         linux/filesystem/directory_iterator.cpp
         linux/filesystem/query.cpp
+        linux/system/process.cpp
         linux/io_uring.cpp
         linux/sync_file.cpp
         memory_region.cpp
@@ -46,6 +47,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Iros")
     target_sources(dius
       PRIVATE
         iros/sync_file.cpp
+        iros/system/process.cpp
     )
 endif()
 

--- a/libs/dius/include/dius/system/prelude.h
+++ b/libs/dius/include/dius/system/prelude.h
@@ -1,3 +1,4 @@
 #pragma once
 
+#include <dius/system/process.h>
 #include <dius/system/system_call.h>

--- a/libs/dius/include/dius/system/process.h
+++ b/libs/dius/include/dius/system/process.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace dius::system {
+[[noreturn]] void exit_process(int status_code);
+}

--- a/libs/dius/include/dius/test/test_manager.h
+++ b/libs/dius/include/dius/test/test_manager.h
@@ -25,10 +25,22 @@ public:
 
     di::Result<void> run_tests(Args& args);
 
+    bool is_test_application() const { return !m_test_cases.empty(); }
+    void handle_assertion_failure();
+
 private:
     TestManager() {}
 
+    void print_failure_message();
+    void print_success_message();
+
+    void run_current_test();
+    void execute_remaining_tests();
+    void final_report();
+
     di::Vector<TestCase> m_test_cases;
-    int m_fail_count { 0 };
+    usize m_current_test_index { 0 };
+    usize m_fail_count { 0 };
+    usize m_success_count { 0 };
 };
 }

--- a/libs/dius/iros/system/process.cpp
+++ b/libs/dius/iros/system/process.cpp
@@ -1,0 +1,8 @@
+#include <dius/prelude.h>
+
+namespace dius::system {
+void exit_process(int code) {
+    (void) dius::system::system_call<i32>(dius::system::Number::exit_task, code);
+    di::unreachable();
+}
+}

--- a/libs/dius/linux/system/process.cpp
+++ b/libs/dius/linux/system/process.cpp
@@ -1,0 +1,8 @@
+#include <dius/prelude.h>
+
+namespace dius::system {
+void exit_process(int code) {
+    (void) dius::system::system_call<i32>(dius::system::Number::exit_group, code);
+    di::unreachable();
+}
+}

--- a/libs/dius/runtime/entry.cpp
+++ b/libs/dius/runtime/entry.cpp
@@ -29,15 +29,6 @@ extern "C" [[noreturn]] [[gnu::naked]] void _start() {
 #endif
 }
 
-extern "C" [[noreturn]] void _exit(int code) {
-#ifdef DIUS_PLATFORM_LINUX
-    (void) dius::system::system_call<i32>(dius::system::Number::exit_group, code);
-#elif defined(DIUS_PLATFORM_IROS)
-    (void) dius::system::system_call<i32>(dius::system::Number::exit_task, code);
-#endif
-    di::unreachable();
-}
-
 #ifdef DIUS_PLATFORM_LINUX
 static char buffer[4096];
 #endif
@@ -57,5 +48,5 @@ extern "C" void dius_entry(int argc, char** argv, char** envp) {
         (*__init_array_start[i])(argc, argv, envp);
     }
 
-    _exit(__extension__ main(argc, argv, envp));
+    dius::system::exit_process(__extension__ main(argc, argv, envp));
 }

--- a/libs/dius/test/test_main.cpp
+++ b/libs/dius/test/test_main.cpp
@@ -2,11 +2,7 @@
 
 namespace dius::test {
 static di::Result<void> main(TestManager::Args& args) {
-    auto result = dius::test::TestManager::the().run_tests(args);
-#ifdef DIUS_PLATFORM_IROS
-    TRY(system::system_call<int>(system::Number::shutdown, !result.has_value()));
-#endif
-    return result;
+    return dius::test::TestManager::the().run_tests(args);
 }
 }
 

--- a/meta/cmake/doxygen.cmake
+++ b/meta/cmake/doxygen.cmake
@@ -4,7 +4,7 @@ find_package(Doxygen
 )
 
 if (DOXYGEN_FOUND)
-include(ExternalProject)
+    include(ExternalProject)
     ExternalProject_Add(doxygen_awesome_css
         GIT_REPOSITORY https://github.com/jothepro/doxygen-awesome-css.git
         GIT_SHALLOW TRUE
@@ -13,6 +13,7 @@ include(ExternalProject)
         BUILD_COMMAND ""
         UPDATE_COMMAND ""
         INSTALL_COMMAND ""
+        EXCLUDE_FROM_ALL 1
     )
     set(DOXYGEN_AWESOME_DIR "${CMAKE_CURRENT_BINARY_DIR}/doxygen_awesome_css-prefix/src/doxygen_awesome_css")
 
@@ -35,6 +36,7 @@ include(ExternalProject)
         __CCPP_END_DECLARATIONS=
         __CCPP_RESTRICT=restrict
     )
+    set(DOXYGEN_HTML_COLORSTYLE "LIGHT")
     set(DOXYGEN_HTML_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/docs/header.html")
     set(DOXYGEN_HTML_EXTRA_STYLESHEET 
         "${DOXYGEN_AWESOME_DIR}/doxygen-awesome.css"


### PR DESCRIPTION
Previously, if any tests failed on Iros it would cause the process to immediately exit. Now, the test runner prints failure messages and gracefully shutdowns the kernel with an exit status. This also removes the usage of `setjmp` and `longjmp` from the project, whose execution in C++ is nearly always UB.