### PR TITLE
dius: call libc exit() if available

### DIFF
--- a/libs/dius/linux/system/process.cpp
+++ b/libs/dius/linux/system/process.cpp
@@ -1,8 +1,16 @@
 #include <dius/prelude.h>
 
+#ifndef DIUS_USE_RUNTIME
+#include <stdlib.h>
+#endif
+
 namespace dius::system {
 void exit_process(int code) {
+#ifdef DIUS_USE_RUNTIME
     (void) dius::system::system_call<i32>(dius::system::Number::exit_group, code);
     di::unreachable();
+#else
+    exit(code);
+#endif
 }
 }


### PR DESCRIPTION
It turns out that the code coverage mechanism registers a atexit() handler which actually writes out the coverage information. So we need to call the proper exit() function for it to work.