### PR TITLE
dius: Add basic WAV file parsing and playback

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/coletrammer/iros_toolchain:iris
 
-ARG USERNAME=iris
+ARG USERNAME=ubuntu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ARG LLVM_VERSION=18
@@ -9,20 +9,21 @@ ARG doxygen_version=1.10.0
 # Install clang
 RUN sudo apt-get -y update \
     && sudo apt-get -y install lsb-release wget software-properties-common gnupg \
-    && wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh \
-    && sudo ./llvm.sh ${LLVM_VERSION} all \
-    && rm llvm.sh
+    && sudo apt-get -y install clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION} clang-format-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} clangd-${LLVM_VERSION} \
+    && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} ${LLVM_VERSION} --slave /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${LLVM_VERSION}  --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_VERSION} --slave /usr/bin/clangd clangd /usr/bin/clangd-${LLVM_VERSION}
 
-# Install dotnet runtime
-RUN sudo apt-get -y install aspnetcore-runtime-6.0
+# This installs any version but is not yet needed, since latest ubuntu already is packing the version we want.
+# && wget https://apt.llvm.org/llvm.sh \
+# && chmod +x llvm.sh \
+# && sudo ./llvm.sh ${LLVM_VERSION} all \
+# && rm llvm.sh
 
 # Install misc debugging tools
 RUN sudo apt-get -y install gdb strace
 
 # Install cmake-format
 RUN sudo apt-get -y install pip \
-    && pip install cmake-format
+    && pip install cmake-format --break-system-packages
 
 # Install prettier
 RUN sudo apt-get -y install npm \
@@ -41,9 +42,7 @@ RUN sudo apt-get -y update \
     && sudo apt-get -y upgrade
 
 # Setup non-root user
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID $USERNAME -d /home/$USERNAME -m -k /dev/skel -s /bin/bash \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && mknod /dev/loop0 b 7 0
 
@@ -55,4 +54,4 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
     && echo "$SNIPPET" >> "/home/$USERNAME/.bashrc" \
     && echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >> "/home/$USERNAME/.bashrc" \
     && chown $USERNAME:$USERNAME "/home/$USERNAME/.bashrc"
-USER iris
+USER ${USERNAME}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,5 +24,5 @@
             ]
         }
     },
-    "remoteUser": "iris"
+    "remoteUser": "ubuntu"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   iros:
     build:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+max_line_length = 120
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{md,yml}]
+indent_size = 2
+
+[.clang*]
+indent_size = 2

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "line_length": {
+        "line_length": 120,
+        "tables": false
+    }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,6 +7,12 @@
             "options": {
                 "tabWidth": 4
             }
+        },
+        {
+            "files": [".clangd", ".clang-tidy", ".clang-format"],
+            "options": {
+                "parser": "yaml"
+            }
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,7 @@
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
     "C_Cpp.autoAddFileAssociations": false,
     "C_Cpp.intelliSenseEngine": "disabled",
-    "clangd.path": "/usr/bin/clangd-16",
+    "clangd.path": "/usr/bin/clangd",
     "clangd.arguments": ["--query-driver=/usr/local/bin/*,/usr/bin/*,${workspaceFolder}/cross/bin/*"],
     "livePreview.autoRefreshPreview": "Never",
     "livePreview.defaultPreviewPath": "build/x86_64/gcc/release/default/html",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,8 @@ endif()
 if(IROS_NonUnityBuildPreset)
     # Generate compile_commands.json using a non-unity build to greatly improve IDE tooling.
     execute_process(
-        COMMAND ${CMAKE_COMMAND} --preset "${IROS_NonUnityBuildPreset}" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        COMMAND ${CMAKE_COMMAND} --preset "${IROS_NonUnityBuildPreset}" "-DIROS_NeverLinkCompileCommands=ON"
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     )
     file(COPY "${CMAKE_BINARY_DIR}/non_unity/compile_commands.json" DESTINATION "${CMAKE_BINARY_DIR}")
 endif()

--- a/docs/di/bytes.md
+++ b/docs/di/bytes.md
@@ -1,0 +1,61 @@
+# Bytes
+
+## Purpose
+
+Most low-level code has to deal directly with bytes. This can be for reading and parsing various file formats,
+or writing data to a frame buffer or physical device. Because C++ does not have a borrow checker, these interfaces
+typically need to be concerned with the lifetime of the bytes they are operating on. The library aims to solve this
+problem by providing a generic (over storage method) byte buffer mechanism. Additionally, there are facilities to
+perform bit-level and byte-level IO asynchronously, while even allowing for zero-copy operations.
+
+## Byte Buffer
+
+In certain scenarios, like creating audio data, code needs to actually write directly to the backing bytes. However,
+most of the time, code is only interested in reading the data. These 2 different scenarios represent exclusive
+references and shared references respectively (in Rust). Both types of references can actually use the same type-erased
+backing store.
+
+### Type Erased Backing Store
+
+Any class which aims to represent a series of contiguous bytes can be represented using only 2 member variables:
+
+1. `byte*` data
+2. `usize` size
+
+Unlike a normal type-erased class, where we would need to perform a indirect (virtual) call in order to access the
+concrete type, we can instead store these member variables directly (as a `di::Span`) on object construction. This
+means that the only member variable which needs to be type-erased are the special member functions. As a further
+optimization, we can require the backing store be trivially relocatable to allow move construction to not require
+an indirect call.
+
+The backing store now looks something like this:
+
+```cpp
+struct AnyBytesStorage {
+    di::Any</* ... */> object;
+    di::Span<byte> data;
+};
+```
+
+### Shared Ownership
+
+Shared ownership requires not giving mutable access to the underlying bytes (we should return a `byte const*` for the
+data). This is to prevent data races. The underlying backing memory can either be reference-counted or statically
+allocated, since the backing object is type-erased. Similarly, the object's destructor can do anything, such as calling
+`operator delete[]`, `munmap`, `smh_unlink`, and so on. This enables zero-copy de-serialization.
+
+For instance, a parser for the WAV file format usually doesn't have to do much. This file format essentially just
+stores raw audio samples on disk (in most cases). Rather than copying the data into our own audio buffer, we can
+now directly reference the file's memory in a safe way, by references a backing store which will eventually call
+`munmap()`.
+
+A key reason this is possible is that we can shrink the shared bye buffer at any time, while still keeping a reference
+to the original object. This is because the actual span of bytes is separate from the underlying object. This ability
+is similar to `std::shared_ptr`.
+
+### Unique Ownership
+
+A unique byte buffer can use the same backing store as the shared variant, but will allow getting a mutable reference
+to the underlying bytes. The key point here is that once we have wrote data into the buffer, we can then safely share
+the data by converting ourselves into a shared reference. This conversion only works 1 way, it is not safe to convert
+a shared reference into an owning one.

--- a/docs/di/intrusive.md
+++ b/docs/di/intrusive.md
@@ -28,14 +28,14 @@ introduce some customization points for intrusive containers.
 
 The intrusive container implementation has 6 customization points.
 
-| Operation                                                 | Description                                                          |
-| --------------------------------------------------------- | -------------------------------------------------------------------- |
-| Tag::node_type(di::InPlaceType<T>) -> Tag::Node           | Get the correct node type for a given T.                             |
-| Tag::down_cast(di::InPlaceType<T>, Tag::Node& node) -> T& | Cast from a node type to the underlying T value.                     |
-| Tag::is_sized(di::InPlaceType<T>) -> bool                 | Determines whether the container offers an O(1) size function.       |
-| Tag::always_store_tail(di::InPlaceType<T>) -> bool        | Determines whether a ForwardList offers O(1) back() and push_back(). |
-| Tag::did_insert(IntrusiveContainer&, Tag::Node& node)     | Hook which intrusive container calls just after inserting the node.  |
-| Tag::did_remove(IntrusiveContainer&, Tag::Node& node)     | Hook which intrusive container calls just after removing the node.   |
+| Operation                                                   | Description                                                          |
+| ----------------------------------------------------------- | -------------------------------------------------------------------- |
+| Tag::node_type(`di::InPlaceType<T>`) -> Tag::Node           | Get the correct node type for a given T.                             |
+| Tag::down_cast(`di::InPlaceType<T>`, Tag::Node& node) -> T& | Cast from a node type to the underlying T value.                     |
+| Tag::is_sized(`di::InPlaceType<T>`) -> bool                 | Determines whether the container offers an O(1) size function.       |
+| Tag::always_store_tail(`di::InPlaceType<T>`) -> bool        | Determines whether a ForwardList offers O(1) back() and push_back(). |
+| Tag::did_insert(IntrusiveContainer&, Tag::Node& node)       | Hook which intrusive container calls just after inserting the node.  |
+| Tag::did_remove(IntrusiveContainer&, Tag::Node& node)       | Hook which intrusive container calls just after removing the node.   |
 
 Notice, there are 2 hooks which are called when inserting and removing elements, respectively. This is used so that
 reference-counted objects can take a reference on insertion and drop a reference on removal. The `did_remove` hook will

--- a/docs/di/serialization.md
+++ b/docs/di/serialization.md
@@ -79,7 +79,9 @@ struct MyType {
     int y_abc;
     int z_abc;
 
-    constexpr friend auto tag_invoke(di::Tag<di::serialize_metadata>, di::InPlaceType<MyType>, di::InPlaceType<di::JsonFormat>) {
+    constexpr friend auto tag_invoke(di::Tag<di::serialize_metadata>,
+                                     di::InPlaceType<MyType>,
+                                     di::InPlaceType<di::JsonFormat>) {
         return di::make_tuple(
             di::field<"xAbc", &MyType::x>,
             di::field<"zAbc", &MyType::z>

--- a/docs/di/table_of_contents.md
+++ b/docs/di/table_of_contents.md
@@ -1,6 +1,7 @@
 # Di Library Documentation
 
 - @subpage md_docs_2di_2allocator - Allocator
+- @subpage md_docs_2di_2bytes - Bytes
 - @subpage md_docs_2di_2execution - Execution
 - @subpage md_docs_2di_2intrusive - Intrusive containers
 - @subpage md_docs_2di_2ipc - Inter-process communication

--- a/docs/di/type_erasure.md
+++ b/docs/di/type_erasure.md
@@ -33,7 +33,7 @@ Now, to use this construction, you can pass a IDrawable by reference to a functi
 memory safe way, either std::unique_ptr or std::shared_ptr must be used. These types cannot be treated as values, so we
 must use indirection. Furthremore, the objects always have to be heap allocated.
 
-## Type Erasure
+## Using Type Erasure
 
 Using type erasure, the interface class poses an abstract set of requirements, and can be constructed from any type
 which meets them. The type internally is memory safe, by either storing the object internally (small object

--- a/docs/dius/linux_startup.md
+++ b/docs/dius/linux_startup.md
@@ -8,7 +8,7 @@ runtime. This assumes a statically linked executable for now.
 The entry point for the program is the is the symbol `_start`. argc, argv, and envp are arranged on the stack as
 follows.
 
-```
+```txt
 +----------------+
 | ...            |
 | elf aux vec    |

--- a/iris/CMakeLists.txt
+++ b/iris/CMakeLists.txt
@@ -87,7 +87,7 @@ if(IROS_BuildIris)
     ExternalProject_Add(
         limine
         GIT_REPOSITORY https://github.com/limine-bootloader/limine.git
-        GIT_TAG v4.x-branch-binary
+        GIT_TAG v7.x-binary
         GIT_SHALLOW TRUE
         TMP_DIR "${CMAKE_SOURCE_DIR}/build/host/tools/limine/tmp"
         STAMP_DIR "${CMAKE_SOURCE_DIR}/build/host/tools/limine/stamp"

--- a/libs/di/include/di/any/storage/shared_storage.h
+++ b/libs/di/include/di/any/storage/shared_storage.h
@@ -91,7 +91,8 @@ public:
     requires(concepts::ConstructibleFrom<T, Args...> && creation_is_fallible(in_place_type<T>))
     constexpr static void create(InPlaceType<Any>, meta::LikeExpected<CreationResult<T>, Any>& self, InPlaceType<T>,
                                  Args&&... args) {
-        auto result = di::allocate_one<T>(self->m_allocator);
+        using Store = detail::ObjectWithRefCount<T>;
+        auto result = di::allocate_one<Store>(self->m_allocator);
         if (!result) {
             self = vocab::Unexpected(util::move(result).error());
             return;
@@ -100,7 +101,7 @@ public:
         auto* pointer = *result;
         util::construct_at(pointer, util::forward<Args>(args)...);
 
-        self->m_pointer = pointer;
+        self->m_pointer = pointer->to_object_pointer();
     }
 
     template<typename T, typename... Args>

--- a/libs/di/include/di/vocab/bytes/byte_buffer.h
+++ b/libs/di/include/di/vocab/bytes/byte_buffer.h
@@ -1,0 +1,202 @@
+#pragma once
+
+#include <di/any/concepts/impl.h>
+#include <di/any/container/any_shared.h>
+#include <di/any/types/method.h>
+#include <di/container/allocator/allocator.h>
+#include <di/function/monad/monad_try.h>
+#include <di/function/tag_invoke.h>
+#include <di/meta/core.h>
+#include <di/meta/operations.h>
+#include <di/meta/vocab.h>
+#include <di/platform/custom.h>
+#include <di/types/in_place.h>
+#include <di/util/exchange.h>
+#include <di/vocab/optional/nullopt.h>
+#include <di/vocab/optional/optional_forward_declaration.h>
+#include <di/vocab/span/span_dynamic_size.h>
+#include <di/vocab/span/span_fixed_size.h>
+
+namespace di::vocab::byte_buffer {
+struct AsWritableByteSpan {
+    using Type = Method<AsWritableByteSpan, Span<byte>(This&)>;
+
+    template<typename T>
+    requires(concepts::TagInvocable<AsWritableByteSpan, T&> ||
+             requires(T& self) {
+                 { self.span() } -> concepts::ConvertibleTo<Span<byte>>;
+             })
+    constexpr static auto operator()(T& self) -> Span<byte> {
+        if constexpr (concepts::TagInvocable<AsWritableByteSpan, T&>) {
+            static_assert(concepts::ConvertibleTo<meta::TagInvokeResult<AsWritableByteSpan, T&>, Span<byte>>,
+                          "as_writable_byte_span() customizations must return a Span<byte>");
+            return tag_invoke(AsWritableByteSpan {}, self);
+        } else {
+            return self.span();
+        }
+    }
+};
+
+struct AsByteSpan {
+    using Type = Method<AsByteSpan, Span<byte const>(This const&)>;
+
+    template<typename T>
+    requires(concepts::TagInvocable<AsByteSpan, T const&> ||
+             requires(T const& self) {
+                 { self.span() } -> concepts::ConvertibleTo<Span<byte const>>;
+             })
+    constexpr static auto operator()(T const& self) -> Span<byte const> {
+        if constexpr (concepts::TagInvocable<AsByteSpan, T const&>) {
+            static_assert(concepts::ConvertibleTo<meta::TagInvokeResult<AsByteSpan, T const&>, Span<byte const>>,
+                          "as_byte_span() customizations must return a Span<byte const>");
+            return tag_invoke(AsByteSpan {}, self);
+        } else {
+            return self.span();
+        }
+    }
+};
+}
+
+namespace di {
+constexpr inline auto as_writable_byte_span = vocab::byte_buffer::AsWritableByteSpan {};
+constexpr inline auto as_byte_span = vocab::byte_buffer::AsByteSpan {};
+}
+
+namespace di::vocab::byte_buffer {
+template<concepts::Allocator Alloc = platform::DefaultAllocator>
+using ByteStore = AnyShared<meta::List<>, Alloc>;
+
+template<concepts::Allocator Alloc = platform::DefaultAllocator>
+class ByteBufferImpl;
+
+template<concepts::Allocator Alloc = platform::DefaultAllocator>
+class ExclusiveByteBufferImpl;
+
+template<concepts::Allocator Alloc>
+class ByteBufferImpl {
+private:
+    using Store = ByteStore<Alloc>;
+
+public:
+    template<concepts::Impl<meta::List<AsByteSpan>> T>
+    requires(!concepts::DerivedFrom<T, ByteBufferImpl> && concepts::FallibleAllocator<Alloc>)
+    static auto create(T&& value) -> meta::LikeExpected<meta::AllocatorResult<Alloc>, ByteBufferImpl> {
+        auto data = as_byte_span(value);
+        auto store = DI_TRY(Store::create(di::forward<T>(value)));
+        return ByteBufferImpl(data, di::move(store));
+    }
+
+    ByteBufferImpl() = default;
+
+    template<concepts::Impl<meta::List<AsByteSpan>> T>
+    requires(!concepts::DerivedFrom<T, ByteBufferImpl> && !concepts::FallibleAllocator<Alloc>)
+    explicit ByteBufferImpl(T&& value) : m_data(as_byte_span(value)), m_store(di::forward<T>(value)) {}
+
+    explicit ByteBufferImpl(Span<byte const> data, Store&& store) : m_data(data), m_store(di::move(store)) {}
+    explicit ByteBufferImpl(Span<byte const> data, Store const& store) : m_data(data), m_store(store) {}
+
+    constexpr auto data() const -> byte const* { return m_data.data(); }
+    constexpr auto size() const -> usize { return m_data.size(); }
+    constexpr auto span() const -> Span<byte const> { return m_data; }
+    constexpr auto empty() const -> bool { return m_data.empty(); }
+
+    constexpr auto store() const& -> Store const& { return m_store; }
+
+    auto first(usize count) const -> Optional<ByteBufferImpl> {
+        return span().first(count) % [&](Span<byte const> data) {
+            return ByteBufferImpl(data, m_store);
+        };
+    }
+
+    auto last(usize count) const -> Optional<ByteBufferImpl> {
+        return span().last(count) % [&](Span<byte const> data) {
+            return ByteBufferImpl(data, m_store);
+        };
+    }
+
+    auto slice(usize offset) const -> Optional<ByteBufferImpl> {
+        return span().subspan(offset) % [&](Span<byte const> data) {
+            return ByteBufferImpl(data, m_store);
+        };
+    }
+
+    auto slice(usize offset, usize count) const -> Optional<ByteBufferImpl> {
+        return span().subspan(offset, count) % [&](Span<byte const> data) {
+            return ByteBufferImpl(data, m_store);
+        };
+    }
+
+private:
+    Span<byte const> m_data;
+    Store m_store;
+};
+
+template<concepts::Allocator Alloc>
+class ExclusiveByteBufferImpl {
+private:
+    using Store = ByteStore<Alloc>;
+    using ByteBuffer = ByteBufferImpl<Alloc>;
+
+public:
+    template<concepts::Impl<meta::List<AsWritableByteSpan>> T>
+    requires(!concepts::DerivedFrom<T, ExclusiveByteBufferImpl> && concepts::FallibleAllocator<Alloc>)
+    static auto create(T&& value) -> meta::LikeExpected<meta::AllocatorResult<Alloc>, ExclusiveByteBufferImpl> {
+        auto data = as_writable_byte_span(value);
+        auto store = DI_TRY(Store::create(di::forward<T>(value)));
+        return ExclusiveByteBufferImpl(data, di::move(store));
+    }
+
+    ExclusiveByteBufferImpl() = default;
+
+    template<concepts::Impl<meta::List<AsWritableByteSpan>> T>
+    requires(!concepts::DerivedFrom<T, ExclusiveByteBufferImpl> && !concepts::FallibleAllocator<Alloc>)
+    explicit ExclusiveByteBufferImpl(T&& value)
+        : m_data(as_writable_byte_span(value)), m_store(di::forward<T>(value)) {}
+
+    explicit ExclusiveByteBufferImpl(Span<byte> data, Store&& store) : m_data(data), m_store(di::move(store)) {}
+
+    ExclusiveByteBufferImpl(ExclusiveByteBufferImpl const&) = delete;
+    ExclusiveByteBufferImpl(ExclusiveByteBufferImpl&& other) : m_store(di::move(other.m_store)) {
+        m_data = di::exchange(other.m_data, Span<byte> {});
+    }
+
+    ExclusiveByteBufferImpl& operator=(ExclusiveByteBufferImpl const&) = delete;
+    ExclusiveByteBufferImpl& operator=(ExclusiveByteBufferImpl&& other) {
+        m_store = di::move(other.m_store);
+        m_data = di::exchange(other.m_data, Span<byte> {});
+    }
+
+    constexpr auto data() const -> byte* { return m_data.data(); }
+    constexpr auto size() const -> usize { return m_data.size(); }
+    constexpr auto span() const -> Span<byte> { return m_data; }
+    constexpr auto empty() const -> bool { return m_data.empty(); }
+
+    constexpr auto store() && -> Store&& {
+        m_data = {};
+        return di::move(*this).m_store;
+    }
+
+    constexpr auto keep_first(usize count) { m_data = m_data.first(count).value_or(Span<byte> {}); }
+    constexpr auto keep_last(usize count) { m_data = m_data.last(count).value_or(Span<byte> {}); }
+    constexpr auto keep_slice(usize offset) { m_data = m_data.subspan(offset).value_or(Span<byte> {}); }
+    constexpr auto keep_slice(usize offset, usize count) {
+        m_data = m_data.subspan(offset, count).value_or(Span<byte> {});
+    }
+
+    auto share() && -> ByteBuffer {
+        auto data = di::exchange(m_data, Span<byte> {});
+        return ByteBuffer(data, di::move(m_store));
+    }
+
+    operator ByteBuffer() && { return share(); }
+
+private:
+    Span<byte> m_data;
+    Store m_store;
+};
+}
+
+namespace di {
+using ByteBuffer = vocab::byte_buffer::ByteBufferImpl<>;
+using ExclusiveByteBuffer = vocab::byte_buffer::ExclusiveByteBufferImpl<>;
+}

--- a/libs/di/include/di/vocab/bytes/byte_buffer.h
+++ b/libs/di/include/di/vocab/bytes/byte_buffer.h
@@ -74,10 +74,10 @@ class ExclusiveByteBufferImpl;
 
 template<concepts::Allocator Alloc>
 class ByteBufferImpl {
-private:
-    using Store = ByteStore<Alloc>;
-
 public:
+    using Store = ByteStore<Alloc>;
+    using ByteBuffer = ByteBufferImpl;
+
     template<concepts::Impl<meta::List<AsByteSpan>> T>
     requires(!concepts::DerivedFrom<T, ByteBufferImpl> && concepts::FallibleAllocator<Alloc>)
     static auto create(T&& value) -> meta::LikeExpected<meta::AllocatorResult<Alloc>, ByteBufferImpl> {
@@ -133,11 +133,10 @@ private:
 
 template<concepts::Allocator Alloc>
 class ExclusiveByteBufferImpl {
-private:
+public:
     using Store = ByteStore<Alloc>;
     using ByteBuffer = ByteBufferImpl<Alloc>;
 
-public:
     template<concepts::Impl<meta::List<AsWritableByteSpan>> T>
     requires(!concepts::DerivedFrom<T, ExclusiveByteBufferImpl> && concepts::FallibleAllocator<Alloc>)
     static auto create(T&& value) -> meta::LikeExpected<meta::AllocatorResult<Alloc>, ExclusiveByteBufferImpl> {
@@ -176,10 +175,10 @@ public:
         return di::move(*this).m_store;
     }
 
-    constexpr auto keep_first(usize count) { m_data = m_data.first(count).value_or(Span<byte> {}); }
-    constexpr auto keep_last(usize count) { m_data = m_data.last(count).value_or(Span<byte> {}); }
-    constexpr auto keep_slice(usize offset) { m_data = m_data.subspan(offset).value_or(Span<byte> {}); }
-    constexpr auto keep_slice(usize offset, usize count) {
+    constexpr auto shrink_to_first(usize count) { m_data = m_data.first(count).value_or(Span<byte> {}); }
+    constexpr auto shrink_to_last(usize count) { m_data = m_data.last(count).value_or(Span<byte> {}); }
+    constexpr auto shrink_to_slice(usize offset) { m_data = m_data.subspan(offset).value_or(Span<byte> {}); }
+    constexpr auto shrink_to_slice(usize offset, usize count) {
         m_data = m_data.subspan(offset, count).value_or(Span<byte> {});
     }
 

--- a/libs/di/tests/test_vocab_byte_buffer.cpp
+++ b/libs/di/tests/test_vocab_byte_buffer.cpp
@@ -1,0 +1,37 @@
+#include <di/container/algorithm/iota.h>
+#include <di/container/vector/vector.h>
+#include <di/vocab/array/array.h>
+#include <di/vocab/bytes/byte_buffer.h>
+#include <dius/test/prelude.h>
+
+namespace vocab_byte_buffer {
+void basic() {
+    auto backing_store = di::Array { 1_b, 2_b, 3_b };
+    auto buffer = di::ByteBuffer(backing_store);
+
+    ASSERT_EQ(buffer.span(), backing_store.span());
+
+    auto slice = *buffer.slice(1, 1);
+    ASSERT_EQ(slice.span(), *backing_store.subspan(1, 1));
+}
+
+void exclusive() {
+    auto backing_store = di::Vector<byte> {};
+    backing_store.resize(10);
+
+    auto buffer = di::ExclusiveByteBuffer(di::move(backing_store));
+    auto data = buffer.span();
+
+    ASSERT_EQ(buffer.size(), 10zu);
+
+    di::container::fill(buffer.span(), 5_b);
+
+    auto shared = di::ByteBuffer(di::move(buffer));
+    ASSERT_EQ(data, shared.span());
+
+    ASSERT(buffer.empty());
+}
+
+TEST(vocab_byte_buffer, basic)
+TEST(vocab_byte_buffer, exclusive)
+}

--- a/libs/dius/include/dius/main.h
+++ b/libs/dius/include/dius/main.h
@@ -5,34 +5,35 @@
 #include <di/container/vector/prelude.h>
 #include <dius/print.h>
 
-#define DIUS_MAIN(Type, NS)                                              \
-    int main(int argc, char** argv) {                                    \
-        auto args = di::Vector<di::TransparentStringView> {};            \
-        for (int i = 0; i < argc; i++) {                                 \
-            char* arg = argv[i];                                         \
-            size_t len = 0;                                              \
-            while (arg[len] != '\0') {                                   \
-                len++;                                                   \
-            }                                                            \
-            args.push_back({ arg, len });                                \
-        }                                                                \
-                                                                         \
-        auto as_span = args.span();                                      \
-        auto parser = di::get_cli_parser<Type>();                        \
-        auto result = parser.parse(as_span);                             \
-        if (!result) {                                                   \
-            dius::eprintln("Failed to parse command line arguments"_sv); \
-            return 2;                                                    \
-        }                                                                \
-                                                                         \
-        using Result = decltype(NS::main(*result));                      \
-        if constexpr (di::concepts::Expected<Result>) {                  \
-            auto main_result = NS::main(*result);                        \
-            if (!main_result) {                                          \
-                return 1;                                                \
-            }                                                            \
-        } else {                                                         \
-            (void) NS::main(*result);                                    \
-        }                                                                \
-        return 0;                                                        \
+#define DIUS_MAIN(Type, NS)                                                                    \
+    int main(int argc, char** argv) {                                                          \
+        auto args = di::Vector<di::TransparentStringView> {};                                  \
+        for (int i = 0; i < argc; i++) {                                                       \
+            char* arg = argv[i];                                                               \
+            size_t len = 0;                                                                    \
+            while (arg[len] != '\0') {                                                         \
+                len++;                                                                         \
+            }                                                                                  \
+            args.push_back({ arg, len });                                                      \
+        }                                                                                      \
+                                                                                               \
+        auto as_span = args.span();                                                            \
+        auto parser = di::get_cli_parser<Type>();                                              \
+        auto result = parser.parse(as_span);                                                   \
+        if (!result) {                                                                         \
+            dius::eprintln("Failed to parse command line arguments"_sv);                       \
+            return 2;                                                                          \
+        }                                                                                      \
+                                                                                               \
+        using Result = decltype(NS::main(*result));                                            \
+        if constexpr (di::concepts::Expected<Result>) {                                        \
+            auto main_result = NS::main(*result);                                              \
+            if (!main_result) {                                                                \
+                dius::eprintln("Command failed: error: {}"_sv, main_result.error().message()); \
+                return 1;                                                                      \
+            }                                                                                  \
+        } else {                                                                               \
+            (void) NS::main(*result);                                                          \
+        }                                                                                      \
+        return 0;                                                                              \
     }

--- a/libs/diusaudio/formats/wav.cpp
+++ b/libs/diusaudio/formats/wav.cpp
@@ -3,24 +3,20 @@
 #include <di/platform/custom.h>
 #include <di/util/uuid.h>
 #include <di/vocab/array/array.h>
+#include <di/vocab/bytes/byte_buffer.h>
 #include <di/vocab/expected/expected.h>
 #include <di/vocab/pointer/box.h>
 #include <dius/filesystem/query/file_size.h>
 #include <dius/print.h>
 #include <dius/sync_file.h>
 #include <diusaudio/formats/wav.h>
+#include <diusaudio/frame_info.h>
 
 namespace audio::formats {
-<<<<<<< HEAD
-auto parse_wav(di::PathView path) -> di::Result<WavResult> {
-||||||| parent of aab2f3c1b (xxx)
-auto parse_wav(di::PathView path) -> di::Result<Frame> {
-=======
 auto parse_wav([[gnu::unused]] di::PathView path) -> di::Result<Frame> {
 #ifdef __iros__
     return di::Unexpected(di::BasicError::NotSupported);
 #else
->>>>>>> aab2f3c1b (xxx)
     auto file = TRY(dius::open_sync(path, dius::OpenMode::Readonly));
 
     // FIXME: this is an obvious race condition with opening the file.
@@ -92,16 +88,9 @@ auto parse_wav([[gnu::unused]] di::PathView path) -> di::Result<Frame> {
         return di::Unexpected(di::BasicError::InvalidArgument);
     }
 
-    auto data = *bytes.subspan(data_offset, data_size);
-
-    auto result = WavResult {};
-    result.data = di::make_box<di::Vector<byte>>();
-    result.data->reserve(data.size());
-    result.data->append_container(data);
-
-    result.frame = Frame(result.data->span(),
-                         FrameInfo((*format)->channel_count, SampleFormat::SignedInt16LE, (*format)->sample_rate));
-
-    return result;
+    auto buffer = di::ByteBuffer(di::move(contents));
+    return Frame(*buffer.slice(data_offset, data_size),
+                 FrameInfo((*format)->channel_count, SampleFormat::SignedInt16LE, (*format)->sample_rate));
+#endif
 }
 }

--- a/libs/diusaudio/formats/wav.cpp
+++ b/libs/diusaudio/formats/wav.cpp
@@ -48,7 +48,6 @@ auto parse_wav([[gnu::unused]] di::PathView path) -> di::Result<Frame> {
         return di::Unexpected(di::BasicError::InvalidArgument);
     }
 
-    dius::eprintln("Chunk size: {}"_sv, header->chunk_size);
     if (header->chunk_size > bytes.size()) {
         return di::Unexpected(di::BasicError::InvalidArgument);
     }
@@ -69,13 +68,6 @@ auto parse_wav([[gnu::unused]] di::PathView path) -> di::Result<Frame> {
         return di::Unexpected(di::BasicError::InvalidArgument);
     }
 
-    dius::eprintln("Format: {}"_sv, (*format)->format_code);
-    dius::eprintln("Format size: {}"_sv, (*format)->chunk_size);
-    dius::eprintln("Channels: {}"_sv, (*format)->channel_count);
-    dius::eprintln("Rate: {}"_sv, (*format)->sample_rate);
-    dius::eprintln("Bits per sample: {}"_sv, (*format)->bits_per_sample);
-    dius::eprintln("Data block size: {}"_sv, (*format)->data_block_size);
-
     if ((*format)->format_code != 1 || (*format)->bits_per_sample != 16) {
         return di::Unexpected(di::BasicError::InvalidArgument);
     }
@@ -94,8 +86,6 @@ auto parse_wav([[gnu::unused]] di::PathView path) -> di::Result<Frame> {
         return di::Unexpected(di::BasicError::InvalidArgument);
     }
 
-    dius::eprintln("Wav data size: {}"_sv, (*wav_data_header)->chunk_size);
-
     auto data_offset = sizeof(WavHeader) + sizeof(WavFmt) + sizeof(WavDataHeader);
     auto data_size = (*wav_data_header)->chunk_size;
     if (data_offset + data_size > bytes.size()) {
@@ -109,8 +99,8 @@ auto parse_wav([[gnu::unused]] di::PathView path) -> di::Result<Frame> {
     result.data->reserve(data.size());
     result.data->append_container(data);
 
-    result.frame =
-        Frame(result.data->span(), (*format)->channel_count, SampleFormat::SignedInt16LE, (*format)->sample_rate);
+    result.frame = Frame(result.data->span(),
+                         FrameInfo((*format)->channel_count, SampleFormat::SignedInt16LE, (*format)->sample_rate));
 
     return result;
 }

--- a/libs/diusaudio/formats/wav.cpp
+++ b/libs/diusaudio/formats/wav.cpp
@@ -1,0 +1,117 @@
+#include <di/bit/endian/little_endian.h>
+#include <di/function/monad/monad_try.h>
+#include <di/platform/custom.h>
+#include <di/util/uuid.h>
+#include <di/vocab/array/array.h>
+#include <di/vocab/expected/expected.h>
+#include <di/vocab/pointer/box.h>
+#include <dius/filesystem/query/file_size.h>
+#include <dius/print.h>
+#include <dius/sync_file.h>
+#include <diusaudio/formats/wav.h>
+
+namespace audio::formats {
+<<<<<<< HEAD
+auto parse_wav(di::PathView path) -> di::Result<WavResult> {
+||||||| parent of aab2f3c1b (xxx)
+auto parse_wav(di::PathView path) -> di::Result<Frame> {
+=======
+auto parse_wav([[gnu::unused]] di::PathView path) -> di::Result<Frame> {
+#ifdef __iros__
+    return di::Unexpected(di::BasicError::NotSupported);
+#else
+>>>>>>> aab2f3c1b (xxx)
+    auto file = TRY(dius::open_sync(path, dius::OpenMode::Readonly));
+
+    // FIXME: this is an obvious race condition with opening the file.
+    auto size = TRY(dius::filesystem::file_size(path));
+
+    auto contents = TRY(file.map(0, size, dius::Protection::Readable, dius::MapFlags::Private));
+    auto bytes = contents.span();
+
+    if (bytes.size() < 12) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    struct [[gnu::packed]] WavHeader {
+        di::Array<byte, 4> chunk_id;
+        di::LittleEndian<u32> chunk_size;
+        di::Array<byte, 4> wave_id;
+    };
+
+    auto* header = bytes.typed_pointer_unchecked<WavHeader>(0);
+    if (header->chunk_id != di::Array { 'R'_b, 'I'_b, 'F'_b, 'F'_b }) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    if (header->wave_id != di::Array { 'W'_b, 'A'_b, 'V'_b, 'E'_b }) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    dius::eprintln("Chunk size: {}"_sv, header->chunk_size);
+    if (header->chunk_size > bytes.size()) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    struct [[gnu::packed]] WavFmt {
+        di::Array<byte, 4> chunk_id;
+        di::LittleEndian<u32> chunk_size;
+        di::LittleEndian<u16> format_code;
+        di::LittleEndian<u16> channel_count;
+        di::LittleEndian<u32> sample_rate;
+        di::LittleEndian<u32> avg_bytes_per_sec;
+        di::LittleEndian<u16> data_block_size;
+        di::LittleEndian<u16> bits_per_sample;
+    };
+
+    auto format = bytes.typed_pointer<WavFmt>(sizeof(WavHeader));
+    if (!format) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    dius::eprintln("Format: {}"_sv, (*format)->format_code);
+    dius::eprintln("Format size: {}"_sv, (*format)->chunk_size);
+    dius::eprintln("Channels: {}"_sv, (*format)->channel_count);
+    dius::eprintln("Rate: {}"_sv, (*format)->sample_rate);
+    dius::eprintln("Bits per sample: {}"_sv, (*format)->bits_per_sample);
+    dius::eprintln("Data block size: {}"_sv, (*format)->data_block_size);
+
+    if ((*format)->format_code != 1 || (*format)->bits_per_sample != 16) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    struct WavDataHeader {
+        di::Array<byte, 4> chunk_id;
+        di::LittleEndian<u32> chunk_size;
+    };
+
+    auto wav_data_header = bytes.typed_pointer<WavDataHeader>(sizeof(WavHeader) + sizeof(WavFmt));
+    if (!wav_data_header) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    if ((*wav_data_header)->chunk_id != di::Array { 'd'_b, 'a'_b, 't'_b, 'a'_b }) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    dius::eprintln("Wav data size: {}"_sv, (*wav_data_header)->chunk_size);
+
+    auto data_offset = sizeof(WavHeader) + sizeof(WavFmt) + sizeof(WavDataHeader);
+    auto data_size = (*wav_data_header)->chunk_size;
+    if (data_offset + data_size > bytes.size()) {
+        return di::Unexpected(di::BasicError::InvalidArgument);
+    }
+
+    auto data = *bytes.subspan(data_offset, data_size);
+
+    auto result = WavResult {};
+    result.data = di::make_box<di::Vector<byte>>();
+    result.data->reserve(data.size());
+    result.data->append_container(data);
+
+    result.frame =
+        Frame(result.data->span(), (*format)->channel_count, SampleFormat::SignedInt16LE, (*format)->sample_rate);
+
+    return result;
+}
+}

--- a/libs/diusaudio/include/diusaudio/formats/wav.h
+++ b/libs/diusaudio/include/diusaudio/formats/wav.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <di/container/path/path_view.h>
+#include <di/container/vector/vector.h>
+#include <di/types/byte.h>
+#include <di/vocab/pointer/box.h>
+#include <diusaudio/frame.h>
+
+namespace audio::formats {
+struct WavResult {
+    di::Box<di::Vector<byte>> data;
+    Frame frame;
+};
+
+auto parse_wav(di::PathView path) -> di::Result<WavResult>;
+}

--- a/libs/diusaudio/include/diusaudio/formats/wav.h
+++ b/libs/diusaudio/include/diusaudio/formats/wav.h
@@ -7,10 +7,5 @@
 #include <diusaudio/frame.h>
 
 namespace audio::formats {
-struct WavResult {
-    di::Box<di::Vector<byte>> data;
-    Frame frame;
-};
-
-auto parse_wav(di::PathView path) -> di::Result<WavResult>;
+auto parse_wav(di::PathView path) -> di::Result<Frame>;
 }

--- a/libs/diusaudio/include/diusaudio/frame.h
+++ b/libs/diusaudio/include/diusaudio/frame.h
@@ -62,6 +62,8 @@ public:
         return { data, sample_count() * channel_count() };
     }
 
+    auto as_raw_bytes() const -> di::Span<byte> { return m_data; }
+
 private:
     di::Span<byte> m_data;
     u32 m_channel_count { 1 };

--- a/libs/diusaudio/include/diusaudio/frame.h
+++ b/libs/diusaudio/include/diusaudio/frame.h
@@ -37,25 +37,25 @@ namespace frame {
         constexpr auto stride() const -> usize { return bytes_per_sample() * channel_count(); }
         constexpr auto byte_count() const -> usize { return sample_count() * stride(); }
 
-        auto as_float32_le() const -> di::Span<di::meta::MaybeConst<is_const, f32>> {
+        auto as_float32_le() const {
             ASSERT_EQ(format(), SampleFormat::Float32LE);
             auto* data = reinterpret_cast<di::meta::MaybeConst<is_const, f32>*>(as_raw_bytes().data());
-            return { data, sample_count() * channel_count() };
+            return di::Span { data, sample_count() * channel_count() };
         }
 
-        auto as_signed_int16_le() const -> di::Span<di::meta::MaybeConst<is_const, i16>> {
+        auto as_signed_int16_le() const {
             ASSERT_EQ(format(), SampleFormat::SignedInt16LE);
             auto* data = reinterpret_cast<di::meta::MaybeConst<is_const, i16>*>(as_raw_bytes().data());
-            return { data, sample_count() * channel_count() };
+            return di::Span { data, sample_count() * channel_count() };
         }
 
-        auto as_signed_int32_le() const -> di::Span<di::meta::MaybeConst<is_const, i32>> {
+        auto as_signed_int32_le() const {
             ASSERT_EQ(format(), SampleFormat::SignedInt32LE);
             auto* data = reinterpret_cast<di::meta::MaybeConst<is_const, i32>*>(as_raw_bytes().data());
-            return { data, sample_count() * channel_count() };
+            return di::Span { data, sample_count() * channel_count() };
         }
 
-        auto as_raw_bytes() const -> di::Span<di::meta::MaybeConst<is_const, byte>> { return m_buffer.span(); }
+        constexpr auto as_raw_bytes() const { return m_buffer.span(); }
 
         constexpr auto shrink_to_first_n_samples(usize count)
         requires(!is_const)

--- a/libs/diusaudio/include/diusaudio/frame.h
+++ b/libs/diusaudio/include/diusaudio/frame.h
@@ -6,39 +6,19 @@
 #include <di/types/integers.h>
 #include <di/util/unreachable.h>
 #include <di/vocab/span/prelude.h>
+#include <diusaudio/frame_info.h>
 
 namespace audio {
-enum class SampleFormat {
-    SignedInt16LE,
-    SignedInt24LE,
-    SignedInt32LE,
-    Float32LE,
-};
-
-constexpr auto format_bytes_per_sample(SampleFormat format) -> usize {
-    using enum SampleFormat;
-    switch (format) {
-        case SignedInt16LE:
-            return 2;
-        case SignedInt24LE:
-            return 3;
-        case SignedInt32LE:
-        case Float32LE:
-            return 4;
-    }
-    di::unreachable();
-}
-
 class Frame {
 public:
     Frame() = default;
 
-    constexpr explicit Frame(di::Span<byte> data, u32 channels, SampleFormat format, u32 sample_rate_hz)
-        : m_data(data), m_channel_count(channels), m_format(format), m_sample_rate_hz(sample_rate_hz) {}
+    constexpr explicit Frame(di::Span<byte> data, FrameInfo info) : m_data(data), m_info(info) {}
 
-    constexpr auto format() const -> SampleFormat { return m_format; }
-    constexpr auto channel_count() const -> usize { return m_channel_count; }
-    constexpr auto sample_rate_hz() const -> usize { return m_sample_rate_hz; }
+    constexpr auto format() const -> SampleFormat { return m_info.format; }
+    constexpr auto channel_count() const -> usize { return m_info.channel_count; }
+    constexpr auto sample_rate_hz() const -> usize { return m_info.sample_rate_hz; }
+    constexpr auto info() const -> FrameInfo { return m_info; }
 
     constexpr auto sample_count() const -> usize { return m_data.size() / stride(); }
     constexpr auto bytes_per_sample() const -> usize { return format_bytes_per_sample(format()); }
@@ -66,8 +46,6 @@ public:
 
 private:
     di::Span<byte> m_data;
-    u32 m_channel_count { 1 };
-    SampleFormat m_format { SampleFormat::Float32LE };
-    u32 m_sample_rate_hz { 44100 };
+    FrameInfo m_info;
 };
 }

--- a/libs/diusaudio/include/diusaudio/frame.h
+++ b/libs/diusaudio/include/diusaudio/frame.h
@@ -1,51 +1,80 @@
 #pragma once
 
 #include <di/assert/prelude.h>
+#include <di/meta/core.h>
+#include <di/meta/util.h>
 #include <di/types/byte.h>
 #include <di/types/floats.h>
 #include <di/types/integers.h>
+#include <di/util/declval.h>
 #include <di/util/unreachable.h>
+#include <di/vocab/bytes/byte_buffer.h>
 #include <di/vocab/span/prelude.h>
 #include <diusaudio/frame_info.h>
 
 namespace audio {
-class Frame {
-public:
-    Frame() = default;
+namespace frame {
+    template<typename Buffer>
+    class FrameImpl {
+    private:
+        constexpr static auto is_const =
+            di::SameAs<di::Span<byte const>, decltype(di::declval<Buffer const&>().span())>;
 
-    constexpr explicit Frame(di::Span<byte> data, FrameInfo info) : m_data(data), m_info(info) {}
+        using ConstBuffer = typename Buffer::ByteBuffer;
 
-    constexpr auto format() const -> SampleFormat { return m_info.format; }
-    constexpr auto channel_count() const -> usize { return m_info.channel_count; }
-    constexpr auto sample_rate_hz() const -> usize { return m_info.sample_rate_hz; }
-    constexpr auto info() const -> FrameInfo { return m_info; }
+    public:
+        FrameImpl() = default;
 
-    constexpr auto sample_count() const -> usize { return m_data.size() / stride(); }
-    constexpr auto bytes_per_sample() const -> usize { return format_bytes_per_sample(format()); }
-    constexpr auto stride() const -> usize { return bytes_per_sample() * channel_count(); }
+        constexpr explicit FrameImpl(Buffer buffer, FrameInfo info) : m_buffer(di::move(buffer)), m_info(info) {}
 
-    auto as_float32_le() const -> di::Span<f32> {
-        ASSERT_EQ(format(), SampleFormat::Float32LE);
-        auto* data = reinterpret_cast<f32*>(m_data.data());
-        return { data, sample_count() * channel_count() };
-    }
+        constexpr auto format() const -> SampleFormat { return m_info.format; }
+        constexpr auto channel_count() const -> usize { return m_info.channel_count; }
+        constexpr auto sample_rate_hz() const -> usize { return m_info.sample_rate_hz; }
+        constexpr auto info() const -> FrameInfo { return m_info; }
 
-    auto as_signed_int16_le() const -> di::Span<i16> {
-        ASSERT_EQ(format(), SampleFormat::SignedInt16LE);
-        auto* data = reinterpret_cast<i16*>(m_data.data());
-        return { data, sample_count() * channel_count() };
-    }
+        constexpr auto sample_count() const -> usize { return as_raw_bytes().size() / stride(); }
+        constexpr auto bytes_per_sample() const -> usize { return format_bytes_per_sample(format()); }
+        constexpr auto stride() const -> usize { return bytes_per_sample() * channel_count(); }
+        constexpr auto byte_count() const -> usize { return sample_count() * stride(); }
 
-    auto as_signed_int32_le() const -> di::Span<i32> {
-        ASSERT_EQ(format(), SampleFormat::SignedInt32LE);
-        auto* data = reinterpret_cast<i32*>(m_data.data());
-        return { data, sample_count() * channel_count() };
-    }
+        auto as_float32_le() const -> di::Span<di::meta::MaybeConst<is_const, f32>> {
+            ASSERT_EQ(format(), SampleFormat::Float32LE);
+            auto* data = reinterpret_cast<di::meta::MaybeConst<is_const, f32>*>(as_raw_bytes().data());
+            return { data, sample_count() * channel_count() };
+        }
 
-    auto as_raw_bytes() const -> di::Span<byte> { return m_data; }
+        auto as_signed_int16_le() const -> di::Span<di::meta::MaybeConst<is_const, i16>> {
+            ASSERT_EQ(format(), SampleFormat::SignedInt16LE);
+            auto* data = reinterpret_cast<di::meta::MaybeConst<is_const, i16>*>(as_raw_bytes().data());
+            return { data, sample_count() * channel_count() };
+        }
 
-private:
-    di::Span<byte> m_data;
-    FrameInfo m_info;
-};
+        auto as_signed_int32_le() const -> di::Span<di::meta::MaybeConst<is_const, i32>> {
+            ASSERT_EQ(format(), SampleFormat::SignedInt32LE);
+            auto* data = reinterpret_cast<di::meta::MaybeConst<is_const, i32>*>(as_raw_bytes().data());
+            return { data, sample_count() * channel_count() };
+        }
+
+        auto as_raw_bytes() const -> di::Span<di::meta::MaybeConst<is_const, byte>> { return m_buffer.span(); }
+
+        constexpr auto shrink_to_first_n_samples(usize count)
+        requires(!is_const)
+        {
+            m_buffer.shrink_to_first(count * stride());
+        }
+
+        operator ConstBuffer() &&
+        requires(!is_const)
+        {
+            return ConstBuffer(di::move(m_buffer), m_info);
+        }
+
+    private:
+        Buffer m_buffer;
+        FrameInfo m_info;
+    };
+}
+
+using Frame = frame::FrameImpl<di::ByteBuffer>;
+using ExclusiveFrame = frame::FrameImpl<di::ExclusiveByteBuffer>;
 }

--- a/libs/diusaudio/include/diusaudio/frame_info.h
+++ b/libs/diusaudio/include/diusaudio/frame_info.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <di/function/tag_invoke.h>
+#include <di/reflect/enumerator.h>
+#include <di/reflect/prelude.h>
+#include <di/types/in_place_type.h>
+#include <di/types/integers.h>
+#include <di/util/unreachable.h>
+
+namespace audio {
+enum class SampleFormat {
+    SignedInt16LE,
+    SignedInt24LE,
+    SignedInt32LE,
+    Float32LE,
+};
+
+constexpr auto tag_invoke(di::Tag<di::reflect>, di::InPlaceType<SampleFormat>) {
+    using enum SampleFormat;
+    return di::make_enumerators(di::enumerator<"SignedInt16LE", SignedInt16LE>,
+                                di::enumerator<"SignedInt24LE", SignedInt24LE>,
+                                di::enumerator<"SignedInt32LE", SignedInt32LE>, di::enumerator<"Float32LE", Float32LE>);
+}
+
+constexpr auto format_bytes_per_sample(SampleFormat format) -> usize {
+    using enum SampleFormat;
+    switch (format) {
+        case SignedInt16LE:
+            return 2;
+        case SignedInt24LE:
+            return 3;
+        case SignedInt32LE:
+        case Float32LE:
+            return 4;
+    }
+    di::unreachable();
+}
+
+struct FrameInfo {
+    u32 channel_count { 1 };
+    SampleFormat format { SampleFormat::Float32LE };
+    u32 sample_rate_hz { 0 };
+
+    constexpr bool operator==(FrameInfo const&) const = default;
+    constexpr auto operator<=>(FrameInfo const&) const = default;
+
+    constexpr friend auto tag_invoke(di::Tag<di::reflect>, di::InPlaceType<FrameInfo>) {
+        return di::make_fields(di::field<"channel_count", &FrameInfo::channel_count>,
+                               di::field<"format", &FrameInfo::format>,
+                               di::field<"sample_rate_hz", &FrameInfo::sample_rate_hz>);
+    }
+};
+}

--- a/libs/diusaudio/include/diusaudio/sink.h
+++ b/libs/diusaudio/include/diusaudio/sink.h
@@ -18,7 +18,7 @@ namespace sink {
     using SinkInterface = di::meta::List<Start, Stop>;
 }
 
-using SinkCallback = di::Function<void(Frame)>;
+using SinkCallback = di::Function<void(ExclusiveFrame&)>;
 using Sink = di::Any<sink::SinkInterface>;
 
 constexpr inline auto start = sink::Start {};

--- a/libs/diusaudio/include/diusaudio/sink.h
+++ b/libs/diusaudio/include/diusaudio/sink.h
@@ -8,6 +8,7 @@
 #include <di/types/integers.h>
 #include <di/vocab/error/result.h>
 #include <diusaudio/frame.h>
+#include <diusaudio/frame_info.h>
 
 namespace audio {
 namespace sink {
@@ -23,6 +24,5 @@ using Sink = di::Any<sink::SinkInterface>;
 constexpr inline auto start = sink::Start {};
 constexpr inline auto stop = sink::Stop {};
 
-auto make_sink(SinkCallback callback, u32 channel_count = 1, SampleFormat format = SampleFormat::Float32LE,
-               u32 sample_rate = 44100) -> di::Result<Sink>;
+auto make_sink(SinkCallback callback, FrameInfo info = {}) -> di::Result<Sink>;
 }

--- a/libs/diusaudio/linux/pipewire.h
+++ b/libs/diusaudio/linux/pipewire.h
@@ -7,6 +7,7 @@
 #include <di/util/noncopyable.h>
 #include <di/vocab/error/result.h>
 #include <diusaudio/frame.h>
+#include <diusaudio/frame_info.h>
 #include <diusaudio/sink.h>
 #include <pipewire/loop.h>
 #include <pipewire/main-loop.h>
@@ -42,8 +43,7 @@ private:
 
 class PipewireStream : di::Immovable {
 public:
-    explicit PipewireStream(PipewireMainloop& loop, SinkCallback callback, u32 channel_count, SampleFormat format,
-                            u32 sample_rate);
+    explicit PipewireStream(PipewireMainloop& loop, SinkCallback callback, FrameInfo info);
     ~PipewireStream();
 
     void connect();
@@ -51,12 +51,8 @@ public:
 private:
     pw_stream* m_stream { nullptr };
     SinkCallback m_sink_callback;
-
-    u32 m_channel_count { 1 };
-    SampleFormat m_format { SampleFormat::Float32LE };
-    u32 m_sample_rate { 44100 };
+    FrameInfo m_info;
 };
 
-auto make_pipewire_sink(SinkCallback callback, u32 channel_count, SampleFormat format,
-                        u32 sample_rate) -> di::Result<Sink>;
+auto make_pipewire_sink(SinkCallback callback, FrameInfo info) -> di::Result<Sink>;
 }

--- a/libs/diusaudio/sink.cpp
+++ b/libs/diusaudio/sink.cpp
@@ -1,5 +1,6 @@
 #include <di/platform/custom.h>
 #include <diusaudio/frame.h>
+#include <diusaudio/frame_info.h>
 #include <diusaudio/sink.h>
 
 #ifdef DIUSAUDIO_HAVE_PIPEWIRE
@@ -7,10 +8,9 @@
 #endif
 
 namespace audio {
-auto make_sink([[maybe_unused]] SinkCallback callback, [[maybe_unused]] u32 channel_count,
-               [[maybe_unused]] SampleFormat format, [[maybe_unused]] u32 sample_rate) -> di::Result<Sink> {
+auto make_sink([[maybe_unused]] SinkCallback callback, [[maybe_unused]] FrameInfo info) -> di::Result<Sink> {
 #ifdef DIUSAUDIO_HAVE_PIPEWIRE
-    return linux::make_pipewire_sink(di::move(callback), channel_count, format, sample_rate);
+    return linux::make_pipewire_sink(di::move(callback), info);
 #else
     return di::Unexpected(di::BasicError::OperationNotSupported);
 #endif

--- a/libs/diusgfx/include/diusgfx/bitmap.h
+++ b/libs/diusgfx/include/diusgfx/bitmap.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <di/assert/assert_bool.h>
+#include <di/meta/util.h>
 #include <di/types/byte.h>
 #include <di/types/integers.h>
+#include <di/vocab/bytes/byte_buffer.h>
 #include <di/vocab/md/extents.h>
 #include <di/vocab/md/extents_forward_declaration.h>
 #include <di/vocab/md/mdspan.h>
@@ -17,23 +19,47 @@ struct ARGBPixel {
     u8 alpha;
 };
 
-class BitMap {
-public:
-    BitMap() = default;
+namespace bitmap {
+    template<typename Buffer>
+    class BitMapImpl {
+    private:
+        constexpr static auto is_const =
+            di::SameAs<di::Span<byte const>, decltype(di::declval<Buffer const&>().span())>;
 
-    constexpr explicit BitMap(di::Span<byte> data, usize width, usize height)
-        : m_data(data), m_width(width), m_height(height) {
-        DI_ASSERT(data.size() == width * height * sizeof(ARGBPixel));
-    }
+        using ConstBuffer = typename Buffer::ByteBuffer;
 
-    constexpr auto width() const -> usize { return m_width; }
-    constexpr auto height() const -> usize { return m_height; }
+    public:
+        BitMapImpl() = default;
 
-    auto argb_pixels() const { return di::MDSpan { reinterpret_cast<ARGBPixel*>(m_data.data()), m_height, m_width }; }
+        constexpr explicit BitMapImpl(Buffer buffer, usize width, usize height)
+            : m_buffer(di::move(buffer)), m_width(width), m_height(height) {
+            DI_ASSERT(byte_count() == width * height * sizeof(ARGBPixel));
+        }
 
-private:
-    di::Span<byte> m_data;
-    usize m_width;
-    usize m_height;
-};
+        constexpr auto width() const -> usize { return m_width; }
+        constexpr auto height() const -> usize { return m_height; }
+        constexpr auto byte_count() const -> usize { return as_raw_bytes().size(); };
+
+        auto argb_pixels() const {
+            return di::MDSpan { reinterpret_cast<di::meta::MaybeConst<is_const, ARGBPixel>*>(as_raw_bytes().data()),
+                                m_height, m_width };
+        }
+
+        constexpr auto as_raw_bytes() const { return m_buffer.span(); }
+
+        operator ConstBuffer() &&
+        requires(!is_const)
+        {
+            return ConstBuffer(di::move(m_buffer), m_width, m_height);
+        }
+
+    private:
+        Buffer m_buffer;
+        usize m_width;
+        usize m_height;
+    };
+}
+
+using BitMap = bitmap::BitMapImpl<di::ByteBuffer>;
+using ExclusiveBitMap = bitmap::BitMapImpl<di::ExclusiveByteBuffer>;
 }

--- a/libs/diusgfx/include/diusgfx/painter.h
+++ b/libs/diusgfx/include/diusgfx/painter.h
@@ -22,5 +22,5 @@ using Painter = di::Any<painter::PainterInterface>;
 constexpr inline auto draw_rect = painter::DrawRect {};
 constexpr inline auto draw_circle = painter::DrawCircle {};
 
-auto make_painter(BitMap bitmap) -> Painter;
+auto make_painter(ExclusiveBitMap bitmap) -> Painter;
 }

--- a/libs/diusgfx/painter.cpp
+++ b/libs/diusgfx/painter.cpp
@@ -6,7 +6,7 @@
 namespace gfx {
 class SimplePainter {
 public:
-    constexpr explicit SimplePainter(BitMap bitmap) : m_bitmap(bitmap) {}
+    explicit SimplePainter(ExclusiveBitMap bitmap) : m_bitmap(di::move(bitmap)) {}
 
 private:
     friend void tag_invoke(di::Tag<draw_rect>, SimplePainter& self, Rect rect, Color color) {
@@ -47,10 +47,10 @@ private:
         }
     }
 
-    BitMap m_bitmap;
+    ExclusiveBitMap m_bitmap;
 };
 
-auto make_painter(BitMap bitmap) -> Painter {
-    return SimplePainter(bitmap);
+auto make_painter(ExclusiveBitMap bitmap) -> Painter {
+    return SimplePainter(di::move(bitmap));
 }
 }

--- a/meta/make-iris-limine-image.sh
+++ b/meta/make-iris-limine-image.sh
@@ -26,7 +26,7 @@ parted -s -- "$IMAGE" \
     mkpart ESP fat32 2048s 100% \
     set 1 esp on
 
-"$IROS_LIMINE_DIR"/limine-deploy "$IMAGE"
+"$IROS_LIMINE_DIR"/limine bios-install "$IMAGE"
 
 cleanup() {
     sync || true
@@ -96,7 +96,7 @@ mount "$LOOP_DEV"p1 "$IROS_BUILD_DIR/mnt"
 
 sudo mkdir -p "$IROS_BUILD_DIR"/mnt/EFI/BOOT
 sudo objcopy -g "$IROS_BUILD_DIR"/iris/iris "$IROS_BUILD_DIR"/mnt/iris
-sudo cp "$INITRD" "$LIMINE_CFG" "$IROS_LIMINE_DIR"/limine.sys "$IROS_BUILD_DIR"/mnt
+sudo cp "$INITRD" "$LIMINE_CFG" "$IROS_LIMINE_DIR"/limine-bios.sys "$IROS_BUILD_DIR"/mnt
 sudo cp "$IROS_LIMINE_DIR"/BOOTX64.EFI "$IROS_BUILD_DIR"/mnt/EFI/BOOT
 
 chmod 777 "$IMAGE"

--- a/userland/audiotest/audio_test.cpp
+++ b/userland/audiotest/audio_test.cpp
@@ -1,22 +1,54 @@
 #include <di/cli/parser.h>
+#include <di/container/algorithm/copy.h>
 #include <di/container/algorithm/fill.h>
 #include <di/container/algorithm/fill_n.h>
+#include <di/container/algorithm/min.h>
+#include <di/container/path/path_view.h>
 #include <di/container/view/range.h>
 #include <di/function/monad/monad_try.h>
 #include <di/math/constants.h>
 #include <di/math/functions.h>
+#include <di/vocab/optional/optional_forward_declaration.h>
 #include <dius/main.h>
+#include <dius/print.h>
+#include <dius/system/process.h>
+#include <diusaudio/formats/wav.h>
 #include <diusaudio/frame.h>
 #include <diusaudio/sink.h>
 
 namespace audiotest {
 struct Args {
+    di::Optional<di::PathView> wav_file;
+
     constexpr static auto get_cli_parser() {
-        return di::cli_parser<Args>("audio_test"_sv, "Iros audio test program"_sv);
+        return di::cli_parser<Args>("audio_test"_sv, "Iros audio test program"_sv)
+            .flag<&Args::wav_file>('w', "wave"_tsv, "Wave file to play"_sv);
     }
 };
 
-di::Result<void> main(Args&) {
+di::Result<void> main(Args& args) {
+    if (args.wav_file) {
+        auto result = TRY(audio::formats::parse_wav(*args.wav_file));
+
+        auto bytes_index = 0;
+        auto sink = TRY(audio::make_sink(
+            [&](audio::Frame frame) {
+                auto output = frame.as_raw_bytes();
+                auto to_copy = di::min(output.size(), result.frame.as_raw_bytes().size() - bytes_index);
+                di::copy(*result.frame.as_raw_bytes().subspan(bytes_index, to_copy), output.data());
+                bytes_index += to_copy;
+
+                if (to_copy == 0) {
+                    dius::system::exit_process(0);
+                }
+            },
+            result.frame.channel_count(), result.frame.format(), result.frame.sample_rate_hz()));
+
+        audio::start(sink);
+
+        return {};
+    }
+
     auto sink = TRY(audio::make_sink([](audio::Frame frame) {
         static int f = 220;
         static f32 accumulator = 0;

--- a/userland/audiotest/audio_test.cpp
+++ b/userland/audiotest/audio_test.cpp
@@ -8,7 +8,6 @@
 #include <di/function/monad/monad_try.h>
 #include <di/math/constants.h>
 #include <di/math/functions.h>
-#include <di/vocab/optional/optional_forward_declaration.h>
 #include <dius/main.h>
 #include <dius/print.h>
 #include <dius/system/process.h>
@@ -30,6 +29,9 @@ di::Result<void> main(Args& args) {
     if (args.wav_file) {
         auto result = TRY(audio::formats::parse_wav(*args.wav_file));
 
+        dius::println("Playing WAV file with info {}, duration {}s"_sv, result.frame.info(),
+                      result.frame.sample_count() / result.frame.sample_rate_hz());
+
         auto bytes_index = 0;
         auto sink = TRY(audio::make_sink(
             [&](audio::Frame frame) {
@@ -42,7 +44,7 @@ di::Result<void> main(Args& args) {
                     dius::system::exit_process(0);
                 }
             },
-            result.frame.channel_count(), result.frame.format(), result.frame.sample_rate_hz()));
+            result.frame.info()));
 
         audio::start(sink);
 

--- a/userland/audiotest/audio_test.cpp
+++ b/userland/audiotest/audio_test.cpp
@@ -6,6 +6,7 @@
 #include <di/container/path/path_view.h>
 #include <di/container/view/range.h>
 #include <di/function/monad/monad_try.h>
+#include <di/math/align_down.h>
 #include <di/math/constants.h>
 #include <di/math/functions.h>
 #include <dius/main.h>
@@ -29,29 +30,31 @@ di::Result<void> main(Args& args) {
     if (args.wav_file) {
         auto result = TRY(audio::formats::parse_wav(*args.wav_file));
 
-        dius::println("Playing WAV file with info {}, duration {}s"_sv, result.frame.info(),
-                      result.frame.sample_count() / result.frame.sample_rate_hz());
+        dius::println("Playing WAV file with info {}, duration {}s"_sv, result.info(),
+                      result.sample_count() / result.sample_rate_hz());
 
         auto bytes_index = 0;
         auto sink = TRY(audio::make_sink(
-            [&](audio::Frame frame) {
+            [&](audio::ExclusiveFrame& frame) {
                 auto output = frame.as_raw_bytes();
-                auto to_copy = di::min(output.size(), result.frame.as_raw_bytes().size() - bytes_index);
-                di::copy(*result.frame.as_raw_bytes().subspan(bytes_index, to_copy), output.data());
+                auto to_copy =
+                    di::align_down(di::min(output.size(), result.as_raw_bytes().size() - bytes_index), frame.stride());
+                di::copy(*result.as_raw_bytes().subspan(bytes_index, to_copy), output.data());
+                frame.shrink_to_first_n_samples(to_copy / frame.stride());
                 bytes_index += to_copy;
 
                 if (to_copy == 0) {
                     dius::system::exit_process(0);
                 }
             },
-            result.frame.info()));
+            result.info()));
 
         audio::start(sink);
 
         return {};
     }
 
-    auto sink = TRY(audio::make_sink([](audio::Frame frame) {
+    auto sink = TRY(audio::make_sink([](audio::ExclusiveFrame& frame) {
         static int f = 220;
         static f32 accumulator = 0;
 


### PR DESCRIPTION
# Summary

This adds a generic `ByteBuffer` vocabulary type which stores memory for audio frames. A WAV file loader is added which produces a frame of audio samples, and the audio test program is now able to playback WAV files.

# Check List

- [x] Self-review the code
- [x] Update tests if necessary
- [x] Update docs if necessary
